### PR TITLE
Add error boundary component and tests

### DIFF
--- a/src/components/layout/ErrorBoundary.tsx
+++ b/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react'
+import { Button } from '@/components/ui/Button'
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error?: Error
+  errorInfo?: ErrorInfo
+}
+
+export interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: React.ComponentType<{ error: Error; resetError: () => void }>
+  onError?: (error: Error, errorInfo: ErrorInfo) => void
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ errorInfo })
+    console.error('ErrorBoundary caught an error:', error, errorInfo)
+    this.props.onError?.(error, errorInfo)
+  }
+
+  resetError = () => {
+    this.setState({ hasError: false, error: undefined, errorInfo: undefined })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        const Fallback = this.props.fallback
+        return (
+          <Fallback error={this.state.error!} resetError={this.resetError} />
+        )
+      }
+
+      return (
+        <div
+          className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div className="max-w-md w-full bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 text-center">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              Something went wrong
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Please try again or refresh the page.
+            </p>
+            <div className="space-y-3">
+              <Button onClick={this.resetError} className="w-full">
+                Try Again
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => window.location.reload()}
+                className="w-full"
+              >
+                Refresh Page
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
-import ReactDOM from "react-dom/client"
+import ReactDOM from 'react-dom/client'
 import { StrictMode } from 'react'
 import App from './App'
+import ErrorBoundary from '@/components/layout/ErrorBoundary'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import ErrorBoundary from '@/components/layout/ErrorBoundary'
+
+const ProblemChild = () => {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary', () => {
+  it('renders fallback when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /try again/i })
+    ).toBeInTheDocument()
+  })
+
+  it('resets error when resetError is called', () => {
+    const Wrapper = () => {
+      const [shouldThrow, setShouldThrow] = useState(true)
+      const Fallback = ({
+        resetError
+      }: {
+        error: Error
+        resetError: () => void
+      }) => (
+        <button
+          onClick={() => {
+            setShouldThrow(false)
+            resetError()
+          }}
+        >
+          retry
+        </button>
+      )
+
+      return (
+        <ErrorBoundary fallback={Fallback}>
+          {shouldThrow ? <ProblemChild /> : <div>safe</div>}
+        </ErrorBoundary>
+      )
+    }
+
+    render(<Wrapper />)
+    const button = screen.getByRole('button', { name: /retry/i })
+    fireEvent.click(button)
+    expect(screen.getByText('safe')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- implement ErrorBoundary layout component
- wrap application with ErrorBoundary
- test ErrorBoundary default and reset behavior

## Testing
- `pnpm build`
- `pnpm exec vitest run --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685cb4be58188322875b96736dbaa886