### PR TITLE
Update test script to run vitest once

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ We follow a trunk-based workflow:
 - **Feature branches** should be short-lived and descriptively named.
 - **Commits** use conventional messages and represent atomic changes.
 - **Pre-commit** hooks run automated linting, formatting and type checks.
+- `pnpm test` runs `vitest run --coverage` to generate a coverage report and exit after one run.
 Please ensure all pull requests pass `pnpm lint`, `pnpm test`, and `pnpm build` before merging.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "start": "node src/server.js",
     "preview": "vite preview",
-    "test": "vitest --coverage",
+    "test": "vitest run --coverage",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "prepare": "husky install",


### PR DESCRIPTION
## Summary
- update `test` script to use `vitest run --coverage`
- mention the new test command in the contribution guidelines

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb756b8a48322aa953fabb68a0994