### PR TITLE
Remove old ErrorBoundary path references

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,9 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react'
 import { Button } from '@/components/ui/Button'
 
+// NOTE: use this component via `@/components/ErrorBoundary`
+// Legacy path '@/components/layout/ErrorBoundary' has been removed.
+
 interface ErrorBoundaryState {
   hasError: boolean
   error?: Error


### PR DESCRIPTION
## Summary
- clarify new ErrorBoundary import path
- verify lint, tests, and build

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685d4611f05083228efdb04c2458df1b