### PR TITLE
Improve ErrorBoundary logging test

### DIFF
--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -55,19 +55,25 @@ describe('ErrorBoundary', () => {
 
   it('logs timestamp, message, and stack when error occurs', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
     render(
       <ErrorBoundary>
         <ProblemChild />
       </ErrorBoundary>
     )
-    expect(spy).toHaveBeenCalledWith(
-      'ErrorBoundary caught',
+
+    const [, log] =
+      spy.mock.calls.find(
+        ([, arg]) => arg && typeof arg === 'object' && 'timestamp' in arg
+      ) ?? []
+    expect(log).toEqual(
       expect.objectContaining({
         timestamp: expect.any(String),
         message: 'boom',
         componentStack: expect.any(String)
       })
     )
+
     spy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- mock `console.error` and assert logged details in ErrorBoundary test

## Testing
- `pnpm lint`
- `pnpm test -- -t ErrorBoundary`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685d4bc40d708322b2ec85ffccc27d91