### PR TITLE
Add CSS variables for light and dark themes

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --ai-primary: 220 80% 56%;
+  --ai-secondary: 270 70% 60%;
+  --ai-neural: 217 19% 27%;
+  --ai-accent: 146 80% 32%;
+  --ai-warning: 17 88% 40%;
+  --ai-surface: 210 40% 96%;
+  --ai-background: 210 40% 98%;
+}
+
+[data-theme="dark"],
+.dark {
+  --ai-primary: 213 95% 68%;
+  --ai-secondary: 270 100% 76%;
+  --ai-neural: 217 19% 85%;
+  --ai-accent: 146 70% 45%;
+  --ai-warning: 17 90% 50%;
+  --ai-surface: 217 33% 18%;
+  --ai-background: 222 47% 11%;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,9 +7,13 @@ export default {
   theme: {
     extend: {
       colors: {
-        'ai-primary': '#3B82F6',
-        'ai-secondary': '#8B5CF6',
-        'ai-accent': '#10B981',
+        'ai-primary': 'hsl(var(--ai-primary))',
+        'ai-secondary': 'hsl(var(--ai-secondary))',
+        'ai-neural': 'hsl(var(--ai-neural))',
+        'ai-accent': 'hsl(var(--ai-accent))',
+        'ai-warning': 'hsl(var(--ai-warning))',
+        'ai-surface': 'hsl(var(--ai-surface))',
+        'ai-background': 'hsl(var(--ai-background))',
       }
     },
   },


### PR DESCRIPTION
## Summary
- define new CSS variables for theme colors in `src/styles/index.css`
- support dark theme variables
- use CSS variables in Tailwind config so classes like `bg-ai-primary` work in both modes

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5ab372b083229526e015d0d4f77a