### PR TITLE
Centralize CSP with Helmet

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'nonce-__NONCE__'; style-src 'self' 'nonce-__NONCE__'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-    />
     <title>ArtOfficial Intelligence</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.5.1",
+    "helmet": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.1",
     "tailwind-merge": "^2.1.0",
-    "zod": "^3.25.67",
-    "express-rate-limit": "^7.5.1"
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.21.2
+      express-rate-limit:
+        specifier: ^7.5.1
+        version: 7.5.1(express@4.21.2)
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1236,6 +1242,12 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -1388,6 +1400,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -3599,6 +3615,10 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  express-rate-limit@7.5.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -3803,6 +3823,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.1.0: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,9 @@
 import express, { Request, Response, NextFunction } from 'express'
 import rateLimit from 'express-rate-limit'
-import crypto from 'crypto'
 import path, { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { promises as fs } from 'fs'
+import { securityMiddleware } from './server/security'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -13,33 +13,25 @@ export function createServer(distDir = path.join(__dirname, '..', 'dist')) {
   // Rate limiter: maximum of 100 requests per 15 minutes
   const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 requests per windowMs
+    max: 100 // limit each IP to 100 requests per windowMs
   })
 
-  app.use((_req: Request, res: Response, next: NextFunction) => {
-    res.locals.nonce = crypto.randomBytes(16).toString('base64')
-    next()
-  })
+  app.use(securityMiddleware())
 
-  app.use((_req: Request, res: Response, next: NextFunction) => {
-    const nonce = res.locals.nonce as string
-    res.setHeader(
-      'Content-Security-Policy',
-      `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`
-    )
-    next()
-  })
-
-  app.get('/', limiter, async (_req: Request, res: Response, next: NextFunction) => {
-    try {
-      const indexPath = path.join(distDir, 'index.html')
-      let html = await fs.readFile(indexPath, 'utf8')
-      html = html.replace(/__NONCE__/g, res.locals.nonce as string)
-      res.type('html').send(html)
-    } catch (error) {
-      next(error)
+  app.get(
+    '/',
+    limiter,
+    async (_req: Request, res: Response, next: NextFunction) => {
+      try {
+        const indexPath = path.join(distDir, 'index.html')
+        let html = await fs.readFile(indexPath, 'utf8')
+        html = html.replace(/__NONCE__/g, res.locals.nonce as string)
+        res.type('html').send(html)
+      } catch (error) {
+        next(error)
+      }
     }
-  })
+  )
 
   app.use(express.static(distDir))
 
@@ -48,14 +40,17 @@ export function createServer(distDir = path.join(__dirname, '..', 'dist')) {
 
 export function startServer(port = Number(process.env.PORT) || 3000) {
   const app = createServer()
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     console.log(`Server running on port ${port}`)
   })
+  return server
 }
 
+/* c8 ignore start */
 if (
   process.argv[1] &&
   path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
 ) {
   startServer()
 }
+/* c8 ignore end */

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -1,0 +1,26 @@
+import helmet from 'helmet'
+import crypto from 'crypto'
+import type { Request, Response, NextFunction } from 'express'
+
+export function securityMiddleware() {
+  const directives = {
+    defaultSrc: ["'self'"],
+    scriptSrc: [
+      "'self'",
+      'https://cdn.jsdelivr.net',
+      (_req: Request, res: Response) => `'nonce-${res.locals.nonce}'`
+    ],
+    styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+    fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+    imgSrc: ["'self'", 'data:', 'https:'],
+    connectSrc: ["'self'", 'https://api.artofficial-intelligence.com', 'ws:']
+  }
+
+  return [
+    (_req: Request, res: Response, next: NextFunction) => {
+      res.locals.nonce = crypto.randomBytes(16).toString('base64')
+      next()
+    },
+    helmet.contentSecurityPolicy({ useDefaults: false, directives })
+  ]
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest'
 import { promises as fs } from 'fs'
 import path from 'path'
 import os from 'os'
-import { createServer } from '../src/server'
+import { createServer, startServer } from '../src/server'
 
 let tmpDir: string
 
@@ -26,5 +26,23 @@ describe('server nonce', () => {
     expect(nonceMatch).toBeTruthy()
     const nonce = nonceMatch![1]
     expect(res.text).toContain(`nonce="${nonce}"`)
+    expect(csp).toContain("default-src 'self'")
+    expect(csp).toContain('https://cdn.jsdelivr.net')
+    expect(csp).toContain('https://fonts.googleapis.com')
+    expect(csp).toContain('https://fonts.gstatic.com')
+    expect(csp).toContain('https://api.artofficial-intelligence.com')
+  })
+
+  it('returns 500 when index load fails', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nonce-test-'))
+    const app = createServer(tmpDir)
+    const res = await request(app).get('/')
+    expect(res.status).toBe(500)
+  })
+
+  it('startServer returns http.Server', async () => {
+    const server = startServer(0)
+    expect(server).toBeTruthy()
+    await new Promise((resolve) => server.close(resolve))
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
       include: [
         'src/components/**/*.{ts,tsx}',
         'src/lib/**/*.ts',
-        'src/server.ts'
+        'src/server.ts',
+        'src/server/**/*.ts'
       ],
       exclude: ['src/components/ui/index.ts']
     }


### PR DESCRIPTION
## Summary
- configure Helmet CSP middleware in `server/security.ts`
- apply security middleware in server
- strip CSP meta tag from `index.html`
- add tests for security headers and startServer
- update coverage config
- install Helmet dependency

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d651f5d8483229d3073c919b4a4b9