### PR TITLE
Add integration test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.4",
     "@types/react": "^18.2.43",
@@ -44,6 +45,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "husky": "^8.0.0",
+    "jest-axe": "^10.0.0",
     "jsdom": "^26.1.0",
     "lint-staged": "^14.0.0",
     "postcss": "^8.4.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
@@ -90,6 +93,9 @@ importers:
       husky:
         specifier: ^8.0.0
         version: 8.0.3
+      jest-axe:
+        specifier: ^10.0.0
+        version: 10.0.0
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -603,6 +609,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -864,6 +876,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axe-core@4.10.2:
+    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
+    engines: {node: '>=4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1532,6 +1548,22 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jest-axe@10.0.0:
+    resolution: {integrity: sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==}
+    engines: {node: '>= 16.0.0'}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.2.2:
+    resolution: {integrity: sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -2883,6 +2915,10 @@ snapshots:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -3210,6 +3246,8 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  axe-core@4.10.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -3942,6 +3980,29 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jest-axe@10.0.0:
+    dependencies:
+      axe-core: 4.10.2
+      chalk: 4.1.2
+      jest-matcher-utils: 29.2.2
+      lodash.merge: 4.6.2
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.2.2:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
 
   jiti@1.21.7: {}
 

--- a/tests/integration/App.integration.test.tsx
+++ b/tests/integration/App.integration.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import App from '@/App'
+import ErrorBoundary from '@/components/ErrorBoundary'
+import { render, screen, userEvent, waitFor } from '../utils/test-utils'
+import { axe } from 'jest-axe'
+
+const mockFetch = (response: unknown, ok = true) => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok,
+    json: async () => response
+  }))
+}
+
+describe('App integration', () => {
+  it('renders home page and navigates', async () => {
+    mockFetch({ status: 'ok' })
+    render(
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    )
+    expect(
+      await screen.findByText(/welcome to artofficial intelligence/i)
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('menuitem', { name: /about/i }))
+    expect(await screen.findByText(/about artofficial intelligence/i)).toBeInTheDocument()
+  })
+
+  it('shows not found on unknown route', async () => {
+    mockFetch({ status: 'ok' })
+    render(<App />, { initialEntries: ['/missing'] })
+    expect(await screen.findByText(/page not found/i)).toBeInTheDocument()
+  })
+
+
+  it('is accessible', async () => {
+    mockFetch({ status: 'ok' })
+    const { container } = render(<App />)
+    await waitFor(() => screen.getByText(/welcome to artofficial intelligence/i))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/tests/integration/ErrorBoundary.integration.test.tsx
+++ b/tests/integration/ErrorBoundary.integration.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+import ErrorBoundary from '@/components/ErrorBoundary'
+import { render, screen, userEvent } from '../utils/test-utils'
+
+const ProblemChild = () => {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary integration', () => {
+  it('shows fallback and resets on retry', async () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})

--- a/tests/setup/integration-setup.ts
+++ b/tests/setup/integration-setup.ts
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach, expect } from 'vitest'
+import { toHaveNoViolations } from 'jest-axe'
+
+expect.extend(toHaveNoViolations)
+
+afterEach(() => {
+  cleanup()
+})

--- a/tests/utils/test-utils.tsx
+++ b/tests/utils/test-utils.tsx
@@ -1,0 +1,20 @@
+import { render, type RenderOptions } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement, FC, ReactNode } from 'react'
+
+interface WrapperProps {
+  initialEntries?: string[]
+}
+
+const Providers: FC<WrapperProps> = ({ children, initialEntries }) => (
+  <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+)
+
+export const customRender = (
+  ui: ReactElement,
+  { initialEntries = ['/'], ...options }: WrapperProps & RenderOptions = {}
+) => render(ui, { wrapper: (props) => <Providers initialEntries={initialEntries} {...props} />, ...options })
+
+export * from '@testing-library/react'
+export { customRender as render, userEvent }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
   test: {
     environment: 'jsdom',
+    setupFiles: ['./tests/setup/integration-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
- add integration tests for application routing and error boundary
- provide utilities and setup for integration testing
- configure Vitest to use new setup
- add supporting dependencies for testing

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d70324230832293196e2cbbcc6845