### PR TITLE
Fix ErrorBoundary imports

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react'
+import React, { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
 
 import { Button } from '@/components/ui/Button'
 

--- a/tests/types.d.ts
+++ b/tests/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'jest-axe'

--- a/tests/utils/test-utils.tsx
+++ b/tests/utils/test-utils.tsx
@@ -1,17 +1,23 @@
-import type { FC, ReactElement } from 'react'
+import type { FC, PropsWithChildren, ReactElement } from 'react'
 
 import { MemoryRouter } from 'react-router-dom'
 
-import { render as rtlRender, screen, waitFor, type RenderOptions } from '@testing-library/react'
+import {
+  type RenderOptions,
+  render as rtlRender,
+  screen,
+  waitFor
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 interface WrapperProps {
   initialEntries?: string[]
 }
 
-const Providers: FC<WrapperProps> = ({ children, initialEntries }) => (
-  <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-)
+const Providers: FC<PropsWithChildren<WrapperProps>> = ({
+  children,
+  initialEntries
+}) => <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
 
 export const customRender = (
   ui: ReactElement,
@@ -25,4 +31,3 @@ export const customRender = (
   })
 export { screen, waitFor }
 export { customRender as render, userEvent }
-


### PR DESCRIPTION
## Summary
- use type-only imports for React types in `ErrorBoundary`
- align test utils with lint rules
- add test type declarations for `jest-axe`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: could not find declaration for 'jest-axe', and lazy imports mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685d892e43c08322a09ba32b92d331f4