### PR TITLE
Add comprehensive component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "node src/server.js",
     "preview": "vite preview",
     "test": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "prepare": "husky install",

--- a/src/components/__tests__/LoadingSpinner.test.tsx
+++ b/src/components/__tests__/LoadingSpinner.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import LoadingSpinner from '../LoadingSpinner'
+
+describe('LoadingSpinner component', () => {
+  it('renders default spinner text', () => {
+    render(<LoadingSpinner />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('supports custom text', () => {
+    render(<LoadingSpinner label="Please wait" />)
+    expect(screen.getByText('Please wait')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['sm', 'h-4 w-4'],
+    ['default', 'h-8 w-8'],
+    ['lg', 'h-12 w-12']
+  ] as const)('applies %s size classes', (size, className) => {
+    const { container } = render(<LoadingSpinner size={size} />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveClass(className)
+  })
+
+  it('sets accessibility attributes', () => {
+    render(<LoadingSpinner />)
+    const wrapper = screen.getByRole('status')
+    expect(wrapper).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('merges custom className', () => {
+    const { container } = render(<LoadingSpinner className="mt-2" />)
+    expect(container.firstChild).toHaveClass('flex', 'mt-2')
+  })
+})

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,36 @@
+import { MemoryRouter } from 'react-router-dom'
+
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { NAVIGATION } from '@/data/navigation'
+
+import { Header } from '../Header'
+
+const renderHeader = (initial: string[] = ['/']) =>
+  render(
+    <MemoryRouter initialEntries={initial}>
+      <Header navigation={NAVIGATION} />
+    </MemoryRouter>
+  )
+
+describe('Header component', () => {
+  it('renders navigation with active item', () => {
+    renderHeader(['/about'])
+    const about = screen.getByRole('menuitem', { name: /about/i })
+    expect(about).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('has accessible navigation structure', () => {
+    renderHeader()
+    const banner = screen.getByRole('banner')
+    const nav = within(banner).getByRole('navigation')
+    expect(within(nav).getAllByRole('menuitem')).toHaveLength(NAVIGATION.length)
+  })
+
+  it('includes responsive menu button', () => {
+    renderHeader()
+    const button = screen.getByRole('button', { name: /open navigation menu/i })
+    expect(button).toHaveClass('md:hidden')
+  })
+})

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Button } from '../Button'
+
+describe('Button component', () => {
+  it.each([
+    ['default', 'default', 'bg-ai-primary'],
+    ['ghost', 'sm', 'bg-transparent']
+  ] as const)('renders %s variant and %s size', (variant, size, className) => {
+    render(
+      <Button variant={variant} size={size}>
+        Test
+      </Button>
+    )
+    const btn = screen.getByRole('button', { name: /test/i })
+    expect(btn).toHaveClass(className)
+  })
+
+  it('forwards ref and handles clicks', async () => {
+    const onClick = vi.fn()
+    const ref = React.createRef<HTMLButtonElement>()
+    render(
+      <Button ref={ref} onClick={onClick}>
+        Click
+      </Button>
+    )
+    await userEvent.click(screen.getByRole('button', { name: /click/i }))
+    expect(onClick).toHaveBeenCalled()
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+  })
+
+  it('prevents interaction when disabled', async () => {
+    const onClick = vi.fn()
+    render(
+      <Button disabled onClick={onClick}>
+        Disabled
+      </Button>
+    )
+    const btn = screen.getByRole('button', { name: /disabled/i })
+    expect(btn).toBeDisabled()
+    await userEvent.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('merges custom className', () => {
+    render(<Button className="mx-2">Class</Button>)
+    expect(screen.getByRole('button')).toHaveClass('mx-2')
+  })
+})

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { cn } from '../utils'
+
+describe('cn utility', () => {
+  it('combines multiple classes', () => {
+    expect(cn('p-2', 'text-center')).toBe('p-2 text-center')
+  })
+
+  it('handles conditional classes', () => {
+    expect(cn('p-2', false && 'hidden', 'block')).toBe('p-2 block')
+  })
+
+  it('resolves tailwind conflicts', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('ignores undefined values', () => {
+    expect(cn('p-2', undefined, 'text-sm')).toBe('p-2 text-sm')
+  })
+})


### PR DESCRIPTION
## Summary
- improve component coverage with new tests for LoadingSpinner
- test UI Button variants, clicks, and ref behavior
- verify layout Header accessibility
- test class name helper utility
- expose `test:coverage` script for clarity

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_685d8b7023988322861167edfe5d27e7