### PR TITLE
Add SEO meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ArtOfficial Intelligence</title>
+    <meta name="description" content="Insights on AI in art and technology." />
+    <meta property="og:title" content="ArtOfficial Intelligence" />
+    <meta
+      property="og:description"
+      content="Insights on AI in art and technology."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/assets/og-image.png" />
+    <meta property="og:url" content="https://artofficial-intelligence.com" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="ArtOfficial Intelligence" />
+    <meta
+      name="twitter:description"
+      content="Insights on AI in art and technology."
+    />
+    <meta name="twitter:image" content="/assets/og-image.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update `index.html` with meta description, Open Graph, and Twitter card tags
- ensure CSP nonce still present
- test server renders meta tags after nonce replacement

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e946d6b6c832291f9c8c6458dc9c9