### PR TITLE
Add article cards and page

### DIFF
--- a/public/articles.json
+++ b/public/articles.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "1",
+    "title": "AI Breakthrough",
+    "excerpt": "A new AI model surpasses expectations.",
+    "author": "Jane Doe",
+    "image": "https://via.placeholder.com/400x200"
+  },
+  {
+    "id": "2",
+    "title": "Machine Learning Trends",
+    "excerpt": "Exploring upcoming trends in ML.",
+    "author": "John Smith",
+    "image": "https://via.placeholder.com/400x200"
+  },
+  {
+    "id": "3",
+    "title": "Robotics Advances",
+    "excerpt": "How robots are transforming industries.",
+    "author": "Alex Johnson",
+    "image": "https://via.placeholder.com/400x200"
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,11 @@ const About = lazyWithPreload(() =>
     default: m.default as React.ComponentType<unknown>
   }))
 )
+const Articles = lazyWithPreload(() =>
+  import('@/pages/Articles').then((m) => ({
+    default: m.default as React.ComponentType<unknown>
+  }))
+)
 const NotFound = lazyWithPreload(() =>
   import('@/pages/NotFound').then((m) => ({
     default: m.default as React.ComponentType<unknown>
@@ -30,6 +35,7 @@ export const App: React.FC = () => {
 
   useEffect(() => {
     void Home.preload()
+    void Articles.preload()
   }, [])
 
   return (
@@ -38,6 +44,7 @@ export const App: React.FC = () => {
       <Suspense fallback={<LoadingSpinner />}>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/articles" element={<Articles />} />
           <Route path="/about" element={<About />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/features/ArticleCard.tsx
+++ b/src/components/features/ArticleCard.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+export interface ArticleCardProps {
+  id?: string
+  title: string
+  excerpt: string
+  author: string
+  image: string
+  'data-testid'?: string
+}
+
+export const ArticleCard: React.FC<ArticleCardProps> = React.memo(
+  ({
+    title,
+    excerpt,
+    author,
+    image,
+    'data-testid': testId = 'article-card'
+  }) => (
+    <article
+      className="rounded-md overflow-hidden border shadow-sm bg-white"
+      data-testid={testId}
+    >
+      <img
+        src={image}
+        alt={`Illustration for ${title}`}
+        className="w-full h-48 object-cover"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        <p className="text-gray-700 mb-2">{excerpt}</p>
+        <p className="text-sm text-gray-500">By {author}</p>
+      </div>
+    </article>
+  )
+)
+
+ArticleCard.displayName = 'ArticleCard'
+
+export default ArticleCard

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -2,5 +2,6 @@ import type { NavigationItem } from '@/types/navigation'
 
 export const NAVIGATION: NavigationItem[] = [
   { label: 'Home', href: '/' },
+  { label: 'Articles', href: '/articles' },
   { label: 'About', href: '/about' }
 ]

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react'
+
+import ArticleCard from '@/components/features/ArticleCard'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+import { fetchWithRetry } from '@/lib/api'
+import type { Article } from '@/types/article'
+
+const Articles: React.FC = () => {
+  const [articles, setArticles] = useState<Article[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchWithRetry('/articles.json')
+        setArticles((await res.json()) as Article[])
+      } catch {
+        setArticles([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void load()
+  }, [])
+
+  if (loading) return <LoadingSpinner />
+
+  return (
+    <section className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Articles</h2>
+      <ul className="grid gap-4 md:grid-cols-2">
+        {articles.map((article) => (
+          <li key={article.id}>
+            <ArticleCard {...article} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default Articles

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,31 +1,59 @@
 import React, { useEffect, useState } from 'react'
 
+import ArticleCard from '@/components/features/ArticleCard'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
 import { fetchWithRetry } from '@/lib/api'
+import type { Article } from '@/types/article'
 
 const Home: React.FC = () => {
-  const [status, setStatus] = useState<string>('')
+  const [status, setStatus] = useState('')
+  const [articles, setArticles] = useState<Article[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const getStatus = async () => {
+    const load = async () => {
       try {
-        const res = await fetchWithRetry('/api/health')
-        const data = await res.json()
-        setStatus(data.status)
-      } catch (error) {
+        const [healthRes, articlesRes] = await Promise.all([
+          fetchWithRetry('/api/health'),
+          fetchWithRetry('/articles.json')
+        ])
+        setStatus((await healthRes.json()).status)
+        setArticles((await articlesRes.json()) as Article[])
+      } catch {
         setStatus('error')
+      } finally {
+        setLoading(false)
       }
     }
 
-    void getStatus()
+    void load()
   }, [])
 
   return (
-    <section className="p-4">
-      <h2 className="text-xl font-semibold">
-        Welcome to ArtOfficial Intelligence
-      </h2>
-      {status && <p data-testid="status">Status: {status}</p>}
-    </section>
+    <main>
+      <section
+        className="py-16 text-center bg-ai-primary text-white"
+        data-testid="hero"
+      >
+        <h1 className="text-3xl font-bold">ArtOfficial Intelligence</h1>
+        <p className="text-lg">Latest news in artificial intelligence</p>
+      </section>
+      <section className="p-4">
+        {status && <p data-testid="status">Status: {status}</p>}
+        {loading ? (
+          <LoadingSpinner />
+        ) : (
+          <ul className="grid gap-4 md:grid-cols-3" data-testid="articles">
+            {articles.slice(0, 3).map((article) => (
+              <li key={article.id}>
+                <ArticleCard {...article} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
   )
 }
 

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,7 @@
+export interface Article {
+  id: string
+  title: string
+  excerpt: string
+  author: string
+  image: string
+}

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -16,7 +16,18 @@ describe('App routing', () => {
       </MemoryRouter>
     )
     expect(
-      await screen.findByText(/Welcome to ArtOfficial Intelligence/)
+      await screen.findByRole('heading', { name: /artofficial intelligence/i })
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to articles page', async () => {
+    render(
+      <MemoryRouter initialEntries={['/articles']}>
+        <App />
+      </MemoryRouter>
+    )
+    expect(
+      await screen.findByRole('heading', { name: /articles/i })
     ).toBeInTheDocument()
   })
 

--- a/tests/ArticleCard.test.tsx
+++ b/tests/ArticleCard.test.tsx
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import ArticleCard from '@/components/features/ArticleCard'
+
+describe('ArticleCard', () => {
+  it('renders article information', () => {
+    render(
+      <ArticleCard
+        title="Test Title"
+        excerpt="Test excerpt"
+        author="Tester"
+        image="test.jpg"
+      />
+    )
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+    expect(screen.getByText('Test excerpt')).toBeInTheDocument()
+    expect(screen.getByText(/Tester/)).toBeInTheDocument()
+  })
+})

--- a/tests/Home.test.tsx
+++ b/tests/Home.test.tsx
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import Home from '@/pages/Home'
+
+const mockArticles = [
+  { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+]
+
+const mockFetch = () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string) => {
+      if (url === '/api/health') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ status: 'ok' })
+        })
+      }
+      return Promise.resolve({ ok: true, json: async () => mockArticles })
+    })
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('Home page', () => {
+  it('displays hero and articles', async () => {
+    mockFetch()
+    render(<Home />)
+    expect(
+      screen.getByRole('heading', { name: /artofficial intelligence/i })
+    ).toBeInTheDocument()
+    expect(await screen.findByText('One')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add ArticleCard component
- create Articles page and sample data
- update Home page with hero and article list
- include Articles route and navigation
- test hero section and article rendering

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e972313d88322a4ff9e840ecd1de2