### PR TITLE
Add tests for Articles page

### DIFF
--- a/tests/Articles.test.js
+++ b/tests/Articles.test.js
@@ -1,0 +1,21 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Articles from '@/pages/Articles';
+const mockArticles = [
+    { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+];
+const mockFetch = () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => mockArticles }));
+};
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+describe('Articles page', () => {
+    it('renders list of articles', async () => {
+        mockFetch();
+        render(_jsx(Articles, {}));
+        expect(await screen.findByText('One')).toBeInTheDocument();
+    });
+});

--- a/tests/Articles.test.tsx
+++ b/tests/Articles.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import Articles from '@/pages/Articles'
+
+const mockArticles = [
+  { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+]
+
+const mockFetch = () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: async () => mockArticles })
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('Articles page', () => {
+  it('renders list of articles', async () => {
+    mockFetch()
+    render(<Articles />)
+    expect(await screen.findByText('One')).toBeInTheDocument()
+  })
+})

--- a/tests/integration/App.integration.test.tsx
+++ b/tests/integration/App.integration.test.tsx
@@ -27,7 +27,7 @@ const mockFetch = () => {
 
 describe('App integration', () => {
   it('renders home page and navigates', async () => {
-    mockFetch({ status: 'ok' })
+    mockFetch()
     render(
       <ErrorBoundary>
         <App />
@@ -43,13 +43,13 @@ describe('App integration', () => {
   })
 
   it('shows not found on unknown route', async () => {
-    mockFetch({ status: 'ok' })
+    mockFetch()
     render(<App />, { initialEntries: ['/missing'] })
     expect(await screen.findByText(/page not found/i)).toBeInTheDocument()
   })
 
   it('is accessible', async () => {
-    mockFetch({ status: 'ok' })
+    mockFetch()
     const { container } = render(<App />)
     await waitFor(() =>
       screen.getByRole('heading', { name: /artofficial intelligence/i })


### PR DESCRIPTION
## Summary
- add tests for Articles page rendering
- fix integration test parameter usage

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685eb4e0b4788322ada2bfb5a47f0e90