### PR TITLE
Add core UI components

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,121 @@
+import React, { forwardRef } from 'react'
+
+import { type VariantProps, cva } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const cardVariants = cva(
+  [
+    'rounded-lg border bg-white dark:bg-gray-800',
+    'text-gray-900 dark:text-white transition-all duration-200'
+  ],
+  {
+    variants: {
+      variant: {
+        default: 'border-gray-200 dark:border-gray-700 shadow-sm',
+        elevated: 'border-gray-200 dark:border-gray-700 shadow-lg',
+        outlined: 'border-2 border-ai-primary/20 shadow-none',
+        ghost: 'border-transparent shadow-none bg-transparent'
+      },
+      padding: {
+        none: 'p-0',
+        sm: 'p-3',
+        default: 'p-6',
+        lg: 'p-8'
+      },
+      interactive: {
+        true: [
+          'cursor-pointer hover:shadow-md transition-shadow',
+          'focus:outline-none focus:ring-2 focus:ring-ai-primary focus:ring-offset-2'
+        ]
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      padding: 'default'
+    }
+  }
+)
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardVariants> {
+  asChild?: boolean
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, padding, interactive, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(cardVariants({ variant, padding, interactive, className }))}
+      tabIndex={interactive ? 0 : undefined}
+      role={interactive ? 'button' : undefined}
+      {...props}
+    />
+  )
+)
+
+Card.displayName = 'Card'
+
+export const CardHeader = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    {...props}
+  />
+))
+CardHeader.displayName = 'CardHeader'
+
+export const CardTitle = forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement> & {
+    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  }
+>(({ className, as: Comp = 'h3', ...props }, ref) => (
+  <Comp
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = 'CardTitle'
+
+export const CardDescription = forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('text-sm text-gray-600 dark:text-gray-400', className)}
+    {...props}
+  />
+))
+CardDescription.displayName = 'CardDescription'
+
+export const CardContent = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+))
+CardContent.displayName = 'CardContent'
+
+export const CardFooter = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center p-6 pt-0', className)}
+    {...props}
+  />
+))
+CardFooter.displayName = 'CardFooter'
+
+export default Card

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,176 @@
+import React, { forwardRef, useId } from 'react'
+
+import { type VariantProps, cva } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const inputVariants = cva(
+  [
+    'flex w-full rounded-md border bg-transparent px-3 py-2 text-sm',
+    'placeholder:text-gray-500 dark:placeholder:text-gray-400',
+    'focus:outline-none focus:ring-2 focus:ring-ai-primary focus:border-transparent',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    'transition-all duration-200'
+  ],
+  {
+    variants: {
+      variant: {
+        default: [
+          'border-gray-300 dark:border-gray-600',
+          'hover:border-gray-400 dark:hover:border-gray-500'
+        ],
+        error: [
+          'border-red-500 dark:border-red-400',
+          'focus:ring-red-500 focus:border-red-500',
+          'text-red-900 dark:text-red-100'
+        ],
+        success: [
+          'border-green-500 dark:border-green-400',
+          'focus:ring-green-500 focus:border-green-500'
+        ]
+      },
+      size: {
+        sm: 'h-8 px-2 text-xs',
+        default: 'h-10 px-3 text-sm',
+        lg: 'h-12 px-4 text-base'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+)
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
+    VariantProps<typeof inputVariants> {
+  label?: string
+  error?: string
+  helperText?: string
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
+  showCharCount?: boolean
+  maxLength?: number
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      label,
+      error,
+      helperText,
+      leftIcon,
+      rightIcon,
+      showCharCount = false,
+      maxLength,
+      id,
+      value,
+      required,
+      ...props
+    },
+    ref
+  ) => {
+    const autoId = useId()
+    const inputId = id || autoId
+    const hasError = Boolean(error)
+    const actualVariant = hasError ? 'error' : variant
+    const currentLength = typeof value === 'string' ? value.length : 0
+
+    return (
+      <div className="space-y-1">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {label}
+            {required && (
+              <span className="text-red-500 ml-1" aria-label="Required field">
+                *
+              </span>
+            )}
+          </label>
+        )}
+        <div className="relative">
+          {leftIcon && (
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <span className="text-gray-400 text-sm" aria-hidden="true">
+                {leftIcon}
+              </span>
+            </div>
+          )}
+          <input
+            id={inputId}
+            ref={ref}
+            className={cn(
+              inputVariants({ variant: actualVariant, size }),
+              { 'pl-10': leftIcon, 'pr-10': rightIcon },
+              className
+            )}
+            aria-invalid={hasError}
+            aria-describedby={cn(
+              hasError && `${inputId}-error`,
+              helperText && `${inputId}-helper`,
+              showCharCount && maxLength && `${inputId}-char-count`
+            )}
+            maxLength={maxLength}
+            value={value}
+            required={required}
+            {...props}
+          />
+          {rightIcon && (
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+              <span className="text-gray-400 text-sm" aria-hidden="true">
+                {rightIcon}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex justify-between items-start min-h-[1.25rem]">
+          <div className="flex-1">
+            {error && (
+              <p
+                id={`${inputId}-error`}
+                className="text-sm text-red-600 dark:text-red-400"
+                role="alert"
+                aria-live="polite"
+              >
+                {error}
+              </p>
+            )}
+            {helperText && !error && (
+              <p
+                id={`${inputId}-helper`}
+                className="text-sm text-gray-500 dark:text-gray-400"
+              >
+                {helperText}
+              </p>
+            )}
+          </div>
+          {showCharCount && maxLength && (
+            <span
+              id={`${inputId}-char-count`}
+              className={cn(
+                'text-xs ml-2 shrink-0',
+                currentLength > maxLength * 0.9
+                  ? 'text-red-500 dark:text-red-400'
+                  : 'text-gray-500 dark:text-gray-400'
+              )}
+              aria-label={`${currentLength} of ${maxLength} characters used`}
+            >
+              {currentLength}/{maxLength}
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+Input.displayName = 'Input'
+
+export default Input

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react'
+
+import { type VariantProps, cva } from 'class-variance-authority'
+import { createPortal } from 'react-dom'
+
+import { cn } from '@/lib/utils'
+
+const modalVariants = cva(
+  'bg-white dark:bg-gray-900 rounded-lg shadow-lg p-6',
+  {
+    variants: {
+      size: {
+        sm: 'max-w-sm',
+        default: 'max-w-lg',
+        lg: 'max-w-2xl'
+      }
+    },
+    defaultVariants: { size: 'default' }
+  }
+)
+
+export interface ModalProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof modalVariants> {
+  open: boolean
+  onClose: () => void
+  'aria-label'?: string
+  'aria-labelledby'?: string
+  'aria-describedby'?: string
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  open,
+  onClose,
+  size,
+  className,
+  children,
+  ...aria
+}) => {
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        data-testid="modal-overlay"
+        className="fixed inset-0 bg-black/50"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(modalVariants({ size }), className, 'z-10')}
+        {...aria}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+Modal.displayName = 'Modal'
+
+export default Modal

--- a/src/components/ui/__tests__/Card.test.tsx
+++ b/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Card, CardContent, CardHeader, CardTitle } from '../Card'
+
+describe('Card component', () => {
+  it('applies variant classes', () => {
+    const { container } = render(
+      <Card variant="elevated">
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+        </CardHeader>
+        <CardContent>Content</CardContent>
+      </Card>
+    )
+    expect(container.firstChild).toHaveClass('shadow-lg')
+  })
+
+  it('is focusable when interactive', async () => {
+    const onClick = userEvent.setup()
+    const handle = vi.fn()
+    render(
+      <Card interactive onClick={handle}>
+        Clickable
+      </Card>
+    )
+    const card = screen.getByRole('button')
+    await onClick.click(card)
+    expect(handle).toHaveBeenCalled()
+  })
+})

--- a/src/components/ui/__tests__/Input.test.tsx
+++ b/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Input } from '../Input'
+
+describe('Input component', () => {
+  it('renders label and helper text', () => {
+    render(<Input label="Email" helperText="info" />)
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByText('info')).toBeInTheDocument()
+  })
+
+  it('displays error state', () => {
+    render(<Input label="Name" error="Required" />)
+    const input = screen.getByLabelText(/name/i)
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('Required')).toBeInTheDocument()
+  })
+
+  it('shows character count', () => {
+    render(
+      <Input
+        label="Bio"
+        showCharCount
+        maxLength={10}
+        value="hello"
+        onChange={() => {}}
+      />
+    )
+    expect(screen.getByText('5/10')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/Modal.test.tsx
+++ b/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Modal } from '../Modal'
+
+describe('Modal component', () => {
+  const renderModal = (open = true, onClose = vi.fn()) =>
+    render(
+      <Modal open={open} onClose={onClose} aria-label="dialog">
+        <div>Content</div>
+      </Modal>
+    )
+
+  it('renders when open', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('calls onClose on overlay click', async () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+    await userEvent.click(screen.getByTestId('modal-overlay'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on Escape key', async () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,12 @@
 export { Button } from './Button'
 export { Drawer } from './Drawer'
+export { Input } from './Input'
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter
+} from './Card'
+export { Modal } from './Modal'


### PR DESCRIPTION
## Summary
- implement Card, Modal, and Input components with TSX patterns
- export new components from ui index
- test components with React Testing Library

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685efa321d9083229b8a6c447d5c52fb