### PR TITLE
Enhance AI news site landing pages with new hero design

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,12 @@
       content="Insights on AI in art and technology."
     />
     <meta name="twitter:image" content="/assets/og-image.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/features/NeuralBackground.tsx
+++ b/src/components/features/NeuralBackground.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react'
+
+interface Node {
+  x: number
+  y: number
+  vx: number
+  vy: number
+}
+
+const createNodes = (count: number, w: number, h: number): Node[] =>
+  Array.from({ length: count }, () => ({
+    x: Math.random() * w,
+    y: Math.random() * h,
+    vx: (Math.random() - 0.5) * 0.5,
+    vy: (Math.random() - 0.5) * 0.5
+  }))
+
+const draw = (ctx: CanvasRenderingContext2D, nodes: Node[]) => {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+  nodes.forEach((n) => {
+    n.x += n.vx
+    n.y += n.vy
+    if (n.x < 0 || n.x > ctx.canvas.width) n.vx *= -1
+    if (n.y < 0 || n.y > ctx.canvas.height) n.vy *= -1
+    ctx.fillStyle = 'rgba(255,255,255,0.8)'
+    ctx.beginPath()
+    ctx.arc(n.x, n.y, 2, 0, Math.PI * 2)
+    ctx.fill()
+  })
+  for (let i = 0; i < nodes.length; i += 1) {
+    for (let j = i + 1; j < nodes.length; j += 1) {
+      const dx = nodes[i].x - nodes[j].x
+      const dy = nodes[i].y - nodes[j].y
+      const d = Math.hypot(dx, dy)
+      if (d < 100) {
+        ctx.strokeStyle = `rgba(255,255,255,${1 - d / 100})`
+        ctx.beginPath()
+        ctx.moveTo(nodes[i].x, nodes[i].y)
+        ctx.lineTo(nodes[j].x, nodes[j].y)
+        ctx.stroke()
+      }
+    }
+  }
+}
+
+const NeuralBackground: React.FC<{ className?: string }> = ({ className }) => {
+  const ref = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return undefined
+    let ctx: CanvasRenderingContext2D | null = null
+    try {
+      ctx = canvas.getContext('2d')
+    } catch {
+      return undefined
+    }
+    if (!ctx) return undefined
+    const nodes = createNodes(25, canvas.width, canvas.height)
+    let id: number
+    const render = () => {
+      draw(ctx, nodes)
+      id = requestAnimationFrame(render)
+    }
+    render()
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  return <canvas ref={ref} width={600} height={300} className={className} />
+}
+
+export default React.memo(NeuralBackground)

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,9 +1,28 @@
 import React from 'react'
 
 const About: React.FC = () => (
-  <section className="p-4">
-    <h2 className="text-xl font-semibold">About ArtOfficial Intelligence</h2>
-  </section>
+  <main className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+    <header className="text-center">
+      <h1 className="text-3xl font-bold text-ai-primary mb-2">
+        About ArtOfficial Intelligence
+      </h1>
+      <p className="text-gray-700 dark:text-gray-300 text-lg">
+        Your trusted source for AI creativity and innovation
+      </p>
+    </header>
+    <section className="space-y-4 leading-relaxed">
+      <p>
+        ArtOfficial Intelligence delivers curated stories on machine learning,
+        robotics and digital art. We translate complex breakthroughs into clear,
+        engaging narratives for creators and technologists alike.
+      </p>
+      <p>
+        Our team blends editorial expertise with modern AI tools to surface the
+        ideas shaping tomorrow. Join us as we explore the frontier of artificial
+        intelligence.
+      </p>
+    </section>
+  </main>
 )
 
 export default About

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
 import ArticleCard from '@/components/features/ArticleCard'
+import NeuralBackground from '@/components/features/NeuralBackground'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
 import { fetchWithRetry } from '@/lib/api'
@@ -33,18 +34,28 @@ const Home: React.FC = () => {
   return (
     <main>
       <section
-        className="py-16 text-center bg-ai-primary text-white"
+        className="relative overflow-hidden py-24 text-center bg-ai-primary text-white"
         data-testid="hero"
       >
-        <h1 className="text-3xl font-bold">ArtOfficial Intelligence</h1>
-        <p className="text-lg">Latest news in artificial intelligence</p>
+        <NeuralBackground className="absolute inset-0 w-full h-full opacity-40" />
+        <div className="relative z-10 max-w-4xl mx-auto px-4">
+          <h1 className="mb-4 text-4xl font-bold md:text-6xl">
+            ArtOfficial Intelligence
+          </h1>
+          <p className="text-lg md:text-xl text-ai-surface">
+            Latest news in artificial intelligence
+          </p>
+        </div>
       </section>
-      <section className="p-4">
+      <section className="p-4 max-w-6xl mx-auto">
         {status && <p data-testid="status">Status: {status}</p>}
         {loading ? (
           <LoadingSpinner />
         ) : (
-          <ul className="grid gap-4 md:grid-cols-3" data-testid="articles">
+          <ul
+            className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 auto-rows-fr"
+            data-testid="articles"
+          >
             {articles.slice(0, 3).map((article) => (
               <li key={article.id}>
                 <ArticleCard {...article} />

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,6 +10,27 @@
   --ai-warning: 17 88% 40%;
   --ai-surface: 210 40% 96%;
   --ai-background: 210 40% 98%;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+}
+
+body {
+  font-family: var(--font-sans);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+.neural-node {
+  @apply absolute w-2 h-2 rounded-full bg-ai-accent opacity-70;
+  animation: float 4s ease-in-out infinite;
 }
 
 [data-theme="dark"],

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -1,0 +1,17 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import About from '@/pages/About'
+
+describe('About page', () => {
+  it('renders site identity content', () => {
+    render(<About />)
+    expect(
+      screen.getByRole('heading', { name: /about artofficial intelligence/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/trusted source for ai creativity/i)
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- load Inter font in `index.html`
- expand Tailwind styles with font variables and neural animation
- add `NeuralBackground` component for animated hero
- redesign `Home` hero and article grid
- flesh out `About` page with branding details
- cover `About` page with a unit test

## Testing
- `pnpm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f71f46a2c8322b7538d1044c8da5e