### PR TITLE
Add article-related schemas

### DIFF
--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,7 +1,53 @@
+import { z } from 'zod'
+
+export interface Author {
+  id: string
+  name: string
+  avatar: string
+}
+
+export const AuthorSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1),
+  avatar: z.string().url()
+})
+export type AuthorFromSchema = z.infer<typeof AuthorSchema>
+
 export interface Article {
   id: string
   title: string
   excerpt: string
-  author: string
+  author: Author
   image: string
+}
+
+export const ArticleSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1),
+  excerpt: z.string().min(1),
+  author: AuthorSchema,
+  image: z.string().url()
+})
+export type ArticleFromSchema = z.infer<typeof ArticleSchema>
+
+export interface APIResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export const ApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.object({
+    success: z.boolean(),
+    data: dataSchema.optional(),
+    error: z.string().optional()
+  })
+export type ApiResponseFromSchema<T extends z.ZodTypeAny> = z.infer<
+  ReturnType<typeof ApiResponseSchema<T>>
+>
+
+export interface LoadingState<T> {
+  data: T
+  loading: boolean
+  error?: string
 }

--- a/tests/articleSchema.test.ts
+++ b/tests/articleSchema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApiResponseSchema, ArticleSchema, AuthorSchema } from '@/types/article'
+
+const validAuthor = {
+  id: 'a1',
+  name: 'Jane Doe',
+  avatar: 'https://example.com/avatar.png'
+}
+
+const validArticle = {
+  id: '1',
+  title: 'Test',
+  excerpt: 'Example',
+  author: validAuthor,
+  image: 'https://example.com/img.png'
+}
+
+describe('Article and Author schemas', () => {
+  it('parses valid author', () => {
+    const parsed = AuthorSchema.parse(validAuthor)
+    expect(parsed.name).toBe('Jane Doe')
+  })
+
+  it('parses valid article', () => {
+    const parsed = ArticleSchema.parse(validArticle)
+    expect(parsed.id).toBe('1')
+  })
+
+  it('throws on invalid article', () => {
+    expect(() => ArticleSchema.parse({})).toThrow()
+  })
+})
+
+describe('ApiResponseSchema', () => {
+  it('parses response with data', () => {
+    const schema = ApiResponseSchema(ArticleSchema)
+    const parsed = schema.parse({ success: true, data: validArticle })
+    expect(parsed.data.title).toBe('Test')
+  })
+})


### PR DESCRIPTION
## Summary
- expand `src/types/article.ts` with article & author types
- add runtime Zod schemas for authors, articles, and API responses
- export inference types from the schemas
- test new validation logic

## Testing
- `npm run test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685f76074fac83228883f0a0c0c01eab