### PR TITLE
Add useArticles hook with validation

### DIFF
--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+import { ApiError, fetchWithRetry } from '@/lib/api'
+import { ArticleSchema, type Article, type LoadingState } from '@/types/article'
+
+interface Options {
+  url?: string
+  timeout?: number
+  retries?: number
+}
+
+export function useArticles({
+  url = '/articles.json',
+  timeout = 5000,
+  retries = 3
+}: Options = {}): LoadingState<Article[]> {
+  const [state, setState] = useState<LoadingState<Article[]>>({ data: [], loading: true })
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchData = async () => {
+      try {
+        const res = await fetchWithRetry(url, { timeout, retries })
+        const data = ArticleSchema.array().parse(await res.json())
+        if (!cancelled) setState({ data, loading: false })
+      } catch (e) {
+        const err = e instanceof ApiError ? e : new ApiError(e instanceof Error ? e.message : 'Unknown error')
+        if (!cancelled) setState({ data: [], loading: false, error: err.message })
+      }
+    }
+    void fetchData()
+    return () => {
+      cancelled = true
+    }
+  }, [url, timeout, retries])
+
+  return state
+}

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -1,39 +1,30 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import ArticleCard from '@/components/features/ArticleCard'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
-import { fetchWithRetry } from '@/lib/api'
-import type { Article } from '@/types/article'
+import { useArticles } from '@/hooks/useArticles'
 
 const Articles: React.FC = () => {
-  const [articles, setArticles] = useState<Article[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await fetchWithRetry('/articles.json')
-        setArticles((await res.json()) as Article[])
-      } catch {
-        setArticles([])
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    void load()
-  }, [])
+  const { data, loading, error } = useArticles()
 
   if (loading) return <LoadingSpinner />
 
   return (
     <section className="p-4">
       <h2 className="text-xl font-semibold mb-4">Articles</h2>
+      {error && <p className="text-red-500">{error}</p>}
       <ul className="grid gap-4 md:grid-cols-2">
-        {articles.map((article) => (
+        {data.map((article) => (
           <li key={article.id}>
-            <ArticleCard {...article} />
+            <ArticleCard
+              {...article}
+              author={
+                typeof article.author === 'string'
+                  ? article.author
+                  : article.author.name
+              }
+            />
           </li>
         ))}
       </ul>

--- a/tests/Articles.test.js
+++ b/tests/Articles.test.js
@@ -4,7 +4,13 @@ import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Articles from '@/pages/Articles';
 const mockArticles = [
-    { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+    {
+        id: '1',
+        title: 'One',
+        excerpt: 'Ex',
+        author: { id: 'a1', name: 'Jane', avatar: 'https://example.com/a.png' },
+        image: 'https://example.com/img.png'
+    }
 ];
 const mockFetch = () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => mockArticles }));

--- a/tests/Articles.test.tsx
+++ b/tests/Articles.test.tsx
@@ -5,7 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import Articles from '@/pages/Articles'
 
 const mockArticles = [
-  { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+  {
+    id: '1',
+    title: 'One',
+    excerpt: 'Ex',
+    author: { id: 'a1', name: 'Jane', avatar: 'https://example.com/a.png' },
+    image: 'https://example.com/img.png'
+  }
 ]
 
 const mockFetch = () => {

--- a/tests/useArticles.test.ts
+++ b/tests/useArticles.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useArticles } from '@/hooks/useArticles'
+
+const mockArticles = [
+  {
+    id: '1',
+    title: 'One',
+    excerpt: 'Ex',
+    author: { id: 'a1', name: 'Jane', avatar: 'https://example.com/a.png' },
+    image: 'https://example.com/img.png'
+  }
+]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('useArticles', () => {
+  it('returns data on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => mockArticles }))
+    const { result } = renderHook(() => useArticles())
+    await waitFor(() => !result.current.loading)
+    expect(result.current.data.length).toBe(1)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('sets error on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+    const { result } = renderHook(() => useArticles({ retries: 0 }))
+    await waitFor(() => !result.current.loading)
+    expect(result.current.error).toMatch('500')
+    expect(result.current.data).toEqual([])
+  })
+
+  it('handles timeout', async () => {
+    vi.stubGlobal('fetch', (_: string, opts: { signal: AbortSignal }) =>
+      new Promise((_res, reject) =>
+        opts.signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        )
+      )
+    )
+    const { result } = renderHook(() =>
+      useArticles({ timeout: 10, retries: 0 })
+    )
+    await waitFor(() => result.current.error !== undefined, { timeout: 50 })
+    expect(result.current.error).toBe('Request timed out')
+  })
+})


### PR DESCRIPTION
## Summary
- fetch articles with new hook and schema validation
- show error messages on Articles page
- test fetching logic

## Testing
- `npm run test` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*

------
https://chatgpt.com/codex/tasks/task_e_685f77dec2208322a310c58ced875a06