### PR TITLE
Add API article fetching

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,6 @@
+
+import { ApiResponseSchema, type Article, ArticleSchema } from '@/types/article'
+
 export class ApiError extends Error {
   status?: number
 
@@ -45,4 +48,29 @@ export async function fetchWithRetry(
     }
   }
   throw new ApiError('Unknown error')
+}
+
+interface ArticleOptions {
+  timeout?: number
+  retries?: number
+}
+
+export async function getArticles({
+  timeout = 5000,
+  retries = 3
+}: ArticleOptions = {}): Promise<Article[]> {
+  const base = import.meta.env?.VITE_API_URL ?? process.env.VITE_API_URL
+  const url = `${base}/articles`
+  try {
+    const res = await fetchWithRetry(url, { timeout, retries })
+    const schema = ApiResponseSchema(ArticleSchema.array())
+    const parsed = schema.parse(await res.json())
+    if (!parsed.success || !parsed.data) {
+      throw new ApiError(parsed.error ?? 'Invalid response')
+    }
+    return parsed.data
+  } catch (error) {
+    if (error instanceof ApiError) throw error
+    throw new ApiError(error instanceof Error ? error.message : 'Unknown error')
+  }
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ApiError, fetchWithRetry } from '@/lib/api'
+import { ApiError, fetchWithRetry, getArticles } from '@/lib/api'
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllEnvs()
 })
 
 describe('fetchWithRetry', () => {
@@ -38,5 +39,47 @@ describe('fetchWithRetry', () => {
     vi.runAllTimers()
     await expect(promise).rejects.toBeInstanceOf(ApiError)
     vi.useRealTimers()
+  })
+})
+
+describe('getArticles', () => {
+  const mockData = {
+    success: true,
+    data: [
+      {
+        id: '1',
+        title: 't',
+        excerpt: 'e',
+        author: { id: 'a', name: 'x', avatar: 'https://ex.com/a.png' },
+        image: 'https://ex.com/img.png'
+      }
+    ]
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_URL', 'https://api')
+  })
+
+  it('returns articles on success', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => mockData })
+    vi.stubGlobal('fetch', fetchMock)
+    const res = await getArticles()
+    expect(res.length).toBe(1)
+    expect(fetchMock).toHaveBeenCalledWith('https://api/articles', expect.anything())
+  })
+
+  it('throws ApiError on api error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: false, error: 'bad' }) })
+    )
+    await expect(getArticles()).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('throws ApiError on fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')))
+    await expect(getArticles({ retries: 0 })).rejects.toBeInstanceOf(ApiError)
   })
 })


### PR DESCRIPTION
## Summary
- add `getArticles` to API module with Zod validation and retry logic
- extend API tests to cover the new helper

## Testing
- `npx vitest run tests/api.test.ts`
- `npx vitest run --coverage` *(fails: useArticles.test.ts timeout expectations)*


------
https://chatgpt.com/codex/tasks/task_e_685f7acedfa88322b30c44dc88980241