### PR TITLE
Add responsive ArticleGrid component

### DIFF
--- a/src/components/layout/ArticleGrid.tsx
+++ b/src/components/layout/ArticleGrid.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { ArticleCard } from '@/components/ui'
+
+import { cn } from '@/lib/utils'
+import { type Article } from '@/types/article'
+
+export interface ArticleGridProps {
+  articles: Article[]
+  className?: string
+  'data-testid'?: string
+}
+
+export const ArticleGrid: React.FC<ArticleGridProps> = React.memo(
+  ({ articles, className = '', 'data-testid': testId = 'article-grid' }) => (
+    <ul
+      className={cn('grid gap-6 sm:grid-cols-2 lg:grid-cols-3', className)}
+      data-testid={testId}
+      role="list"
+    >
+      {articles.map((article) => (
+        <li key={article.id} role="listitem">
+          <ArticleCard {...article} author={article.author.name} />
+        </li>
+      ))}
+    </ul>
+  )
+)
+
+ArticleGrid.displayName = 'ArticleGrid'
+
+export default ArticleGrid

--- a/src/components/layout/__tests__/ArticleGrid.test.tsx
+++ b/src/components/layout/__tests__/ArticleGrid.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ArticleGrid } from '../ArticleGrid'
+
+const articles = [
+  {
+    id: '1',
+    title: 'First',
+    excerpt: 'One',
+    author: { id: 'a1', name: 'Jane', avatar: 'a.jpg' },
+    image: 'img1.jpg'
+  },
+  {
+    id: '2',
+    title: 'Second',
+    excerpt: 'Two',
+    author: { id: 'a2', name: 'John', avatar: 'b.jpg' },
+    image: 'img2.jpg'
+  }
+]
+
+describe('ArticleGrid component', () => {
+  it('renders list of articles with proper roles', () => {
+    render(<ArticleGrid articles={articles} />)
+    const list = screen.getByRole('list')
+    expect(list).toBeInTheDocument()
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('applies responsive grid classes', () => {
+    const { container } = render(<ArticleGrid articles={articles} />)
+    expect(container.firstChild).toHaveClass(
+      'grid',
+      'gap-6',
+      'sm:grid-cols-2',
+      'lg:grid-cols-3'
+    )
+  })
+})

--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { ApiError, fetchWithRetry } from '@/lib/api'
-import { ArticleSchema, type Article, type LoadingState } from '@/types/article'
+import { type Article, ArticleSchema, type LoadingState } from '@/types/article'
 
 interface Options {
   url?: string
@@ -14,7 +14,10 @@ export function useArticles({
   timeout = 5000,
   retries = 3
 }: Options = {}): LoadingState<Article[]> {
-  const [state, setState] = useState<LoadingState<Article[]>>({ data: [], loading: true })
+  const [state, setState] = useState<LoadingState<Article[]>>({
+    data: [],
+    loading: true
+  })
 
   useEffect(() => {
     let cancelled = false
@@ -24,8 +27,12 @@ export function useArticles({
         const data = ArticleSchema.array().parse(await res.json())
         if (!cancelled) setState({ data, loading: false })
       } catch (e) {
-        const err = e instanceof ApiError ? e : new ApiError(e instanceof Error ? e.message : 'Unknown error')
-        if (!cancelled) setState({ data: [], loading: false, error: err.message })
+        const err =
+          e instanceof ApiError
+            ? e
+            : new ApiError(e instanceof Error ? e.message : 'Unknown error')
+        if (!cancelled)
+          setState({ data: [], loading: false, error: err.message })
       }
     }
     void fetchData()


### PR DESCRIPTION
## Summary
- add `ArticleGrid` component under layout
- list `ArticleCard` items with responsive grid classes
- include ARIA list roles for accessibility
- test rendering and CSS classes for responsiveness
- fix minor lint issue in `useArticles`

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685fe28dfab08322806978befa517dca