### PR TITLE
Add API base URL env setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# ArtOfficial Intelligence Website Environment Variables
+VITE_APP_NAME=ArtOfficial Intelligence
+VITE_APP_DESCRIPTION=Your source for AI news and insights
+VITE_APP_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -9,12 +9,18 @@ afterEach(() => {
 
 describe('fetchWithRetry', () => {
   it('returns response on success', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://api')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }))
     const res = await fetchWithRetry('/api')
     expect(res.ok).toBe(true)
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      'https://api/api',
+      expect.anything()
+    )
   })
 
   it('retries and throws ApiError on failure', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://api')
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({ ok: false, status: 500 })
@@ -26,6 +32,7 @@ describe('fetchWithRetry', () => {
 
   it('throws ApiError on timeout', async () => {
     vi.useFakeTimers()
+    vi.stubEnv('VITE_API_URL', 'https://api')
     vi.stubGlobal(
       'fetch',
       (_url: string, opts: { signal: AbortSignal }) =>
@@ -76,12 +83,10 @@ describe('getArticles', () => {
   it('throws ApiError on api error', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          json: async () => ({ success: false, error: 'bad' })
-        })
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: false, error: 'bad' })
+      })
     )
     await expect(getArticles()).rejects.toBeInstanceOf(ApiError)
   })

--- a/tests/integration/App.integration.test.tsx
+++ b/tests/integration/App.integration.test.tsx
@@ -11,13 +11,14 @@ const mockFetch = () => {
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string) => {
-      if (url === '/api/health') {
+      const base = process.env.VITE_API_URL
+      if (url === `${base}/api/health`) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ status: 'ok' })
         })
       }
-      if (url === '/articles.json') {
+      if (url === `${base}/articles.json`) {
         return Promise.resolve({ ok: true, json: async () => [] })
       }
       return Promise.resolve({ ok: true, json: async () => ({}) })

--- a/tests/setup/integration-setup.ts
+++ b/tests/setup/integration-setup.ts
@@ -8,3 +8,5 @@ expect.extend(toHaveNoViolations)
 afterEach(() => {
   cleanup()
 })
+
+process.env.VITE_API_URL = 'http://localhost'


### PR DESCRIPTION
## Summary
- support base API url via `import.meta.env.VITE_API_URL`
- fetch utilities use this base automatically
- fix API and integration tests for new behaviour
- document env vars in `.env.example`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685fe7577dc48322abf66b40b68eabf5