### PR TITLE
Fix mobile menu close on navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Link, useLocation } from 'react-router-dom'
 
@@ -26,6 +26,10 @@ export const Header: React.FC<HeaderProps> = React.memo(
         })),
       [navigation, location.pathname]
     )
+
+    useEffect(() => {
+      setMobileOpen(false)
+    }, [location.pathname])
 
     const toggleMobile = useCallback(() => {
       setMobileOpen((prev) => !prev)

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -48,4 +48,16 @@ describe('Header component', () => {
     await userEvent.keyboard('{Escape}')
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
+
+  it('closes menu on navigation', async () => {
+    renderHeader()
+    const button = screen.getByRole('button', { name: /open navigation menu/i })
+    await userEvent.click(button)
+    const menu = screen.getByRole('menu')
+    expect(menu).toBeInTheDocument()
+    await userEvent.click(
+      within(menu).getByRole('menuitem', { name: /about/i })
+    )
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- update header to close mobile drawer when path changes
- add regression test verifying mobile menu closes on route change

## Testing
- `npm run test` *(fails: concurrency issues)*
- `npx vitest run --coverage --minWorkers=1 --maxWorkers=1`

------
https://chatgpt.com/codex/tasks/task_e_685fef1906b88322990491014312962c