### PR TITLE
Improve header navigation with React Router

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/ui/Button'
 import { Drawer } from '@/components/ui/Drawer'
@@ -45,14 +45,17 @@ export const Header: React.FC<HeaderProps> = React.memo(
       [toggleMobile]
     )
 
+    const navigate = useNavigate()
+
     const handleKeyDown = useCallback(
       (event: React.KeyboardEvent, href: string) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()
-          window.location.assign(href)
+          setMobileOpen(false)
+          navigate(href)
         }
       },
-      []
+      [navigate]
     )
 
     return (

--- a/tests/integration/App.integration.test.tsx
+++ b/tests/integration/App.integration.test.tsx
@@ -43,6 +43,22 @@ describe('App integration', () => {
     ).toBeInTheDocument()
   })
 
+  it('navigates with keyboard without page reload', async () => {
+    mockFetch()
+    render(
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    )
+    await screen.findByRole('heading', { name: /artofficial intelligence/i })
+    const link = screen.getByRole('menuitem', { name: /about/i })
+    link.focus()
+    await userEvent.keyboard(' ')
+    expect(
+      await screen.findByText(/about artofficial intelligence/i)
+    ).toBeInTheDocument()
+  })
+
   it('shows not found on unknown route', async () => {
     mockFetch()
     render(<App />, { initialEntries: ['/missing'] })


### PR DESCRIPTION
## Summary
- use `useNavigate` in `Header` for keyboard navigation
- reset menu state on navigation and prevent full page reload
- test keyboard navigation to ensure SPA behaviour

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ff17ef31c8322bc35c0fadd5b824e