### PR TITLE
Improve drawer focus handling

### DIFF
--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,25 +1,23 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { createPortal } from 'react-dom'
+
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 interface DrawerProps {
   open: boolean
   onClose: () => void
   children: React.ReactNode
+  toggleRef?: React.RefObject<HTMLElement>
 }
 
-export const Drawer: React.FC<DrawerProps> = ({ open, onClose, children }) => {
-  useEffect(() => {
-    if (!open) return
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
-  }, [open, onClose])
+export const Drawer: React.FC<DrawerProps> = ({
+  open,
+  onClose,
+  children,
+  toggleRef
+}) => {
+  const ref = useFocusTrap(open, toggleRef, onClose)
 
   if (!open) return null
   return createPortal(
@@ -31,8 +29,10 @@ export const Drawer: React.FC<DrawerProps> = ({ open, onClose, children }) => {
         onClick={onClose}
       />
       <div
+        ref={ref}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
         className="relative w-64 max-w-full h-full bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300"
       >
         {children}

--- a/src/components/ui/__tests__/Drawer.test.tsx
+++ b/src/components/ui/__tests__/Drawer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -31,5 +31,33 @@ describe('Drawer', () => {
     renderDrawer(true, onClose)
     await userEvent.keyboard('{Escape}')
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('traps focus and restores to toggle button', async () => {
+    const Example = () => {
+      const [open, setOpen] = React.useState(false)
+      const btnRef = React.useRef<HTMLButtonElement>(null)
+      return (
+        <>
+          <button ref={btnRef} onClick={() => setOpen(true)}>
+            toggle
+          </button>
+          <Drawer open={open} onClose={() => setOpen(false)} toggleRef={btnRef}>
+            <button>inside</button>
+          </Drawer>
+        </>
+      )
+    }
+
+    render(<Example />)
+    const user = userEvent.setup()
+    const toggle = screen.getByText('toggle')
+    await user.click(toggle)
+    const dialog = screen.getByRole('dialog')
+    const inside = screen.getByText('inside')
+    inside.focus()
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(inside).toHaveFocus()
+    fireEvent.keyDown(dialog, { key: 'Escape' })
   })
 })

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+
+export function useFocusTrap(
+  active: boolean,
+  returnRef?: React.RefObject<HTMLElement>,
+  onEscape?: () => void
+) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (!active || !el) return
+    const prev = document.activeElement as HTMLElement | null
+    const restore = returnRef?.current
+    const nodes = el.querySelectorAll<HTMLElement>(
+      'a[href],button:not([disabled]),textarea,input,select,[tabindex]:not([tabindex="-1"])'
+    )
+    const firstNode = nodes[0]
+    const lastNode = nodes[nodes.length - 1]
+    const first = firstNode ?? el
+    const last = lastNode ?? el
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        if (e.shiftKey) {
+          if (
+            document.activeElement === first ||
+            document.activeElement === el
+          ) {
+            e.preventDefault()
+            last.focus()
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onEscape?.()
+      }
+    }
+    el.focus()
+    document.addEventListener('keydown', handle)
+    return () => {
+      document.removeEventListener('keydown', handle)
+      ;(restore ?? prev)?.focus()
+    }
+  }, [active, returnRef, onEscape])
+  return ref
+}


### PR DESCRIPTION
## Summary
- add a `useFocusTrap` hook for managing focus
- update `Drawer` component to trap focus and restore on close
- test Drawer focus behaviour

## Testing
- `npm run lint`
- `npx vitest run src/components/ui/__tests__/Drawer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_685ff3fce0b48322b7f82bcf8bf42f44