### PR TITLE
Update articles author structure

### DIFF
--- a/public/articles.json
+++ b/public/articles.json
@@ -3,21 +3,21 @@
     "id": "1",
     "title": "AI Breakthrough",
     "excerpt": "A new AI model surpasses expectations.",
-    "author": "Jane Doe",
+    "author": { "id": "a1", "name": "Jane Doe", "avatar": "https://via.placeholder.com/40" },
     "image": "https://via.placeholder.com/400x200"
   },
   {
     "id": "2",
     "title": "Machine Learning Trends",
     "excerpt": "Exploring upcoming trends in ML.",
-    "author": "John Smith",
+    "author": { "id": "a2", "name": "John Smith", "avatar": "https://via.placeholder.com/40" },
     "image": "https://via.placeholder.com/400x200"
   },
   {
     "id": "3",
     "title": "Robotics Advances",
     "excerpt": "How robots are transforming industries.",
-    "author": "Alex Johnson",
+    "author": { "id": "a3", "name": "Alex Johnson", "avatar": "https://via.placeholder.com/40" },
     "image": "https://via.placeholder.com/400x200"
   }
 ]

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -17,14 +17,7 @@ const Articles: React.FC = () => {
       <ul className="grid gap-4 md:grid-cols-2">
         {data.map((article) => (
           <li key={article.id}>
-            <ArticleCard
-              {...article}
-              author={
-                typeof article.author === 'string'
-                  ? article.author
-                  : article.author.name
-              }
-            />
+            <ArticleCard {...article} author={article.author.name} />
           </li>
         ))}
       </ul>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -58,7 +58,7 @@ const Home: React.FC = () => {
           >
             {articles.slice(0, 3).map((article) => (
               <li key={article.id}>
-                <ArticleCard {...article} />
+                <ArticleCard {...article} author={article.author.name} />
               </li>
             ))}
           </ul>

--- a/tests/Home.test.tsx
+++ b/tests/Home.test.tsx
@@ -5,7 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import Home from '@/pages/Home'
 
 const mockArticles = [
-  { id: '1', title: 'One', excerpt: 'Ex', author: 'A', image: 'img' }
+  {
+    id: '1',
+    title: 'One',
+    excerpt: 'Ex',
+    author: { id: 'a1', name: 'A', avatar: 'a.png' },
+    image: 'img'
+  }
 ]
 
 const mockFetch = () => {


### PR DESCRIPTION
## Summary
- use author objects in `articles.json`
- pass author name to `ArticleCard` on Articles/Home pages
- update Home page test for new author format

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686000595ed08322929d3e81eacc6336