### PR TITLE
Fix focus management and remove build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pnpm-debug.log*
 .DS_Store
 
 coverage/
+src/data/navigation.js

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Header } from '@/components/layout/Header'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
 import { NAVIGATION } from '@/data/navigation'
+import { useRouteFocus } from '@/hooks/useRouteFocus'
 import { lazyWithPreload } from '@/lib/lazyWithPreload'
 import { validateNavigation } from '@/lib/validation'
 
@@ -32,6 +33,8 @@ const NotFound = lazyWithPreload(() =>
 
 export const App: React.FC = () => {
   const navigation = validateNavigation(NAVIGATION)
+
+  useRouteFocus()
 
   useEffect(() => {
     void Home.preload()

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -17,6 +17,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
   ({ navigation, className = '', 'data-testid': testId = 'header' }) => {
     const location = useLocation()
     const [mobileOpen, setMobileOpen] = useState(false)
+    const toggleRef = useRef<HTMLButtonElement>(null)
 
     const items = useMemo(
       () =>
@@ -91,6 +92,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
                 ))}
               </ul>
               <Button
+                ref={toggleRef}
                 variant="ghost"
                 size="sm"
                 className="md:hidden"
@@ -115,7 +117,12 @@ export const Header: React.FC<HeaderProps> = React.memo(
                   />
                 </svg>
               </Button>
-              <Drawer open={mobileOpen} onClose={() => setMobileOpen(false)}>
+              <Drawer
+                open={mobileOpen}
+                onClose={() => setMobileOpen(false)}
+                toggleRef={toggleRef}
+                ariaLabel="Mobile menu"
+              >
                 <ul id="mobile-menu" role="menu" className="p-4 space-y-2">
                   {items.map(({ href, label, isActive }) => (
                     <li key={href} role="none">

--- a/src/components/ui/ArticleCard.tsx
+++ b/src/components/ui/ArticleCard.tsx
@@ -3,10 +3,8 @@ import React from 'react'
 import type { Article } from '@/types/article'
 
 export interface ArticleCardProps
-  extends Pick<
-    Article,
-    'id' | 'title' | 'excerpt' | 'author' | 'image' | 'imageAlt'
-  > {
+  extends Pick<Article, 'id' | 'title' | 'excerpt' | 'image' | 'imageAlt'> {
+  author: string
   onClick?: (id: string) => void
   'data-testid'?: string
 }

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -9,13 +9,15 @@ interface DrawerProps {
   onClose: () => void
   children: React.ReactNode
   toggleRef?: React.RefObject<HTMLElement>
+  ariaLabel?: string
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
   open,
   onClose,
   children,
-  toggleRef
+  toggleRef,
+  ariaLabel
 }) => {
   const ref = useFocusTrap(open, toggleRef, onClose)
 
@@ -32,6 +34,7 @@ export const Drawer: React.FC<DrawerProps> = ({
         ref={ref}
         role="dialog"
         aria-modal="true"
+        aria-label={ariaLabel}
         tabIndex={-1}
         className="relative w-64 max-w-full h-full bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300"
       >

--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -1,7 +1,0 @@
-export const NAVIGATION = [
-    { label: 'Home', href: '/' },
-    { label: 'Articles', href: '/articles' },
-    { label: 'Search', href: '/search' },
-    { label: 'Contact', href: '/contact' },
-    { label: 'About', href: '/about' }
-];

--- a/src/hooks/useRouteFocus.ts
+++ b/src/hooks/useRouteFocus.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { useLocation } from 'react-router-dom'
+
+export function useRouteFocus() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    const main = document.querySelector('main') as HTMLElement | null
+    if (main) {
+      if (!main.hasAttribute('tabindex')) {
+        main.setAttribute('tabindex', '-1')
+      }
+      main.focus()
+    }
+  }, [pathname])
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 const About: React.FC = () => (
-  <main className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+  <main
+    id="main-content"
+    tabIndex={-1}
+    className="max-w-4xl mx-auto px-4 py-8 space-y-6"
+  >
     <header className="text-center">
       <h1 className="text-3xl font-bold text-ai-primary mb-2">
         About ArtOfficial Intelligence

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -11,17 +11,19 @@ const Articles: React.FC = () => {
   if (loading) return <LoadingSpinner />
 
   return (
-    <section className="p-4">
-      <h2 className="text-xl font-semibold mb-4">Articles</h2>
-      {error && <p className="text-red-500">{error}</p>}
-      <ul className="grid gap-4 md:grid-cols-2">
-        {data.map((article) => (
-          <li key={article.id}>
-            <ArticleCard {...article} author={article.author.name} />
-          </li>
-        ))}
-      </ul>
-    </section>
+    <main id="main-content" tabIndex={-1} className="p-4">
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Articles</h2>
+        {error && <p className="text-red-500">{error}</p>}
+        <ul className="grid gap-4 md:grid-cols-2">
+          {data.map((article) => (
+            <li key={article.id}>
+              <ArticleCard {...article} author={article.author.name} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
   )
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -32,7 +32,7 @@ const Home: React.FC = () => {
   }, [])
 
   return (
-    <main>
+    <main id="main-content" tabIndex={-1}>
       <section
         className="relative overflow-hidden py-24 text-center bg-ai-primary text-white"
         data-testid="hero"

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 const NotFound: React.FC = () => (
-  <section className="p-4">
+  <main id="main-content" tabIndex={-1} className="p-4">
     <h2 className="text-xl font-semibold">Page Not Found</h2>
-  </section>
+  </main>
 )
 
 export default NotFound

--- a/src/types/cors.d.ts
+++ b/src/types/cors.d.ts
@@ -1,0 +1,5 @@
+declare module 'cors' {
+  import { RequestHandler } from 'express'
+  function cors(options?: unknown): RequestHandler
+  export default cors
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tests/useRouteFocus.test.tsx
+++ b/tests/useRouteFocus.test.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react'
+
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useRouteFocus } from '@/hooks/useRouteFocus'
+
+function TestComponent() {
+  useRouteFocus()
+  const navigate = useNavigate()
+  useEffect(() => {
+    navigate('/about')
+  }, [navigate])
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <main id="main-content" tabIndex={-1}>
+            Home
+          </main>
+        }
+      />
+      <Route
+        path="/about"
+        element={
+          <main id="main-content" tabIndex={-1}>
+            About
+          </main>
+        }
+      />
+    </Routes>
+  )
+}
+
+describe('useRouteFocus', () => {
+  it('focuses main element on route change', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <TestComponent />
+      </MemoryRouter>
+    )
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByText('About'))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- return focus to hamburger when mobile menu closes
- focus the main area on route changes
- label the drawer dialog
- remove compiled navigation.js from source and ignore it
- add missing type declarations and tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860059666f08322ae63e0be46940511