### PR TITLE
Fix mobile menu and focus

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -32,6 +32,18 @@ export const Header: React.FC<HeaderProps> = React.memo(
       setMobileOpen(false)
     }, [location.pathname])
 
+    useEffect(() => {
+      document.body.classList.toggle('overflow-hidden', mobileOpen)
+      const handleResize = () => {
+        if (window.innerWidth >= 768) setMobileOpen(false)
+      }
+      window.addEventListener('resize', handleResize)
+      return () => {
+        document.body.classList.remove('overflow-hidden')
+        window.removeEventListener('resize', handleResize)
+      }
+    }, [mobileOpen])
+
     const toggleMobile = useCallback(() => {
       setMobileOpen((prev) => !prev)
     }, [])
@@ -96,14 +108,16 @@ export const Header: React.FC<HeaderProps> = React.memo(
                 variant="ghost"
                 size="sm"
                 className="md:hidden"
-                aria-label="Open navigation menu"
+                aria-label={
+                  mobileOpen ? 'Close navigation menu' : 'Open navigation menu'
+                }
                 aria-expanded={mobileOpen}
                 aria-controls="mobile-menu"
                 onClick={toggleMobile}
                 onKeyDown={handleToggleKeyDown}
               >
                 <svg
-                  className="w-6 h-6"
+                  className="w-6 h-6 transition-transform"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -113,7 +127,11 @@ export const Header: React.FC<HeaderProps> = React.memo(
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
+                    d={
+                      mobileOpen
+                        ? 'M6 18L18 6M6 6l12 12'
+                        : 'M4 6h16M4 12h16M4 18h16'
+                    }
                   />
                 </svg>
               </Button>

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { createPortal } from 'react-dom'
 
@@ -20,8 +20,17 @@ export const Drawer: React.FC<DrawerProps> = ({
   ariaLabel
 }) => {
   const ref = useFocusTrap(open, toggleRef, onClose)
+  const [visible, setVisible] = useState(open)
 
-  if (!open) return null
+  useEffect(() => {
+    if (open) setVisible(true)
+  }, [open])
+
+  const handleTransitionEnd = () => {
+    if (!open) setVisible(false)
+  }
+
+  if (!visible) return null
   return createPortal(
     <div className="fixed inset-0 z-50 flex">
       <div
@@ -36,7 +45,8 @@ export const Drawer: React.FC<DrawerProps> = ({
         aria-modal="true"
         aria-label={ariaLabel}
         tabIndex={-1}
-        className="relative w-64 max-w-full h-full bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300"
+        onTransitionEnd={handleTransitionEnd}
+        className={`relative w-64 max-w-full h-full bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300 ${open ? 'translate-x-0' : '-translate-x-full'}`}
       >
         {children}
       </div>


### PR DESCRIPTION
## Summary
- enhance Header mobile menu state management
- add smooth transition to Drawer and keep focus trapped

## Testing
- `npm run lint`
- `npm test` *(fails: HTMLCanvasElement.getContext not implemented, Header test failing)*

------
https://chatgpt.com/codex/tasks/task_e_68600a9eac4483228367f83686896ca6