### PR TITLE
Add react-helmet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.5.1",
-    "cors": "^2.8.5",
     "helmet": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.20.1",
     "tailwind-merge": "^2.1.0",
     "zod": "^3.25.67"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       express:
         specifier: ^4.19.2
         version: 4.21.2
@@ -29,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-helmet-async:
+        specifier: ^1.3.0
+        version: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.20.1
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1513,6 +1519,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
@@ -2383,6 +2393,9 @@ packages:
   into-stream@3.1.0:
     resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
     engines: {node: '>=4'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3259,6 +3272,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -3307,6 +3323,18 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-helmet-async@1.3.0:
+    resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -3501,6 +3529,9 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.34.2:
     resolution: {integrity: sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==}
@@ -5512,6 +5543,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cross-spawn@5.1.0:
     dependencies:
       lru-cache: 4.1.5
@@ -6618,6 +6654,10 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 1.1.0
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -7455,6 +7495,12 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proto-list@1.2.4: {}
 
   proxy-addr@2.0.7:
@@ -7499,6 +7545,20 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-fast-compare@3.2.2: {}
+
+  react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      invariant: 2.2.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
+
+  react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
@@ -7746,6 +7806,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
+
+  shallowequal@1.1.0: {}
 
   sharp@0.34.2:
     dependencies:

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { Helmet } from 'react-helmet-async'
+
+export interface SEOHeadProps {
+  title: string
+  description?: string
+  children?: React.ReactNode
+}
+
+const SEOHead: React.FC<SEOHeadProps> = React.memo(
+  ({ title, description, children }) => (
+    <Helmet>
+      <title>{title}</title>
+      {description ? (
+        <meta name="description" content={description} />
+      ) : null}
+      {children}
+    </Helmet>
+  )
+)
+
+SEOHead.displayName = 'SEOHead'
+
+export default SEOHead

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
@@ -42,11 +42,15 @@ describe('Header component', () => {
     await userEvent.keyboard('{Enter}')
     expect(screen.getByRole('menu')).toBeInTheDocument()
     await userEvent.keyboard('{Escape}')
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    )
     await userEvent.keyboard(' ')
     expect(screen.getByRole('menu')).toBeInTheDocument()
     await userEvent.keyboard('{Escape}')
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    )
   })
 
   it('closes menu on navigation', async () => {
@@ -58,6 +62,8 @@ describe('Header component', () => {
     await userEvent.click(
       within(menu).getByRole('menuitem', { name: /about/i })
     )
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    )
   })
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom/client'
 
 import { BrowserRouter } from 'react-router-dom'
 
+import { HelmetProvider } from 'react-helmet-async'
+
 import ErrorBoundary from '@/components/ErrorBoundary'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
@@ -12,11 +14,13 @@ import App from './App'
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
     <ErrorBoundary>
-      <BrowserRouter>
-        <Suspense fallback={<LoadingSpinner />}>
-          <App />
-        </Suspense>
-      </BrowserRouter>
+      <HelmetProvider>
+        <BrowserRouter>
+          <Suspense fallback={<LoadingSpinner />}>
+            <App />
+          </Suspense>
+        </BrowserRouter>
+      </HelmetProvider>
     </ErrorBoundary>
   </StrictMode>
 )

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 
+import SEOHead from '@/components/SEOHead'
+
 const About: React.FC = () => (
   <main
     id="main-content"
     tabIndex={-1}
     className="max-w-4xl mx-auto px-4 py-8 space-y-6"
   >
+    <SEOHead
+      title="About - ArtOfficial Intelligence"
+      description="Learn more about ArtOfficial Intelligence"
+    />
     <header className="text-center">
       <h1 className="text-3xl font-bold text-ai-primary mb-2">
         About ArtOfficial Intelligence

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import NeuralBackground from '@/components/features/NeuralBackground'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import SEOHead from '@/components/SEOHead'
 import ArticleCard from '@/components/ui/ArticleCard'
 
 import { fetchWithRetry } from '@/lib/api'
@@ -33,6 +34,10 @@ const Home: React.FC = () => {
 
   return (
     <main id="main-content" tabIndex={-1}>
+      <SEOHead
+        title="ArtOfficial Intelligence"
+        description="Latest news in artificial intelligence"
+      />
       <section
         className="relative overflow-hidden py-24 text-center bg-ai-primary text-white"
         data-testid="hero"

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from './utils/test-utils'
 import { describe, expect, it } from 'vitest'
 
 import About from '@/pages/About'
@@ -13,5 +13,12 @@ describe('About page', () => {
     expect(
       screen.getByText(/trusted source for ai creativity/i)
     ).toBeInTheDocument()
+  })
+
+  it('sets page title', async () => {
+    render(<About />)
+    await waitFor(() =>
+      expect(document.title).toBe('About - ArtOfficial Intelligence')
+    )
   })
 })

--- a/tests/Home.test.tsx
+++ b/tests/Home.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from './utils/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import Home from '@/pages/Home'
@@ -41,5 +41,14 @@ describe('Home page', () => {
       screen.getByRole('heading', { name: /artofficial intelligence/i })
     ).toBeInTheDocument()
     expect(await screen.findByText('One')).toBeInTheDocument()
+  })
+
+  it('sets page title', async () => {
+    mockFetch()
+    render(<Home />)
+    await screen.findByRole('heading', { name: /artofficial intelligence/i })
+    await waitFor(() =>
+      expect(document.title).toBe('ArtOfficial Intelligence')
+    )
   })
 })

--- a/tests/SEOHead.test.tsx
+++ b/tests/SEOHead.test.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom/vitest'
+import { render, waitFor } from './utils/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import SEOHead from '@/components/SEOHead'
+
+describe('SEOHead', () => {
+  it('sets title and description meta', async () => {
+    render(<SEOHead title="Test" description="desc" />)
+    await waitFor(() => expect(document.title).toBe('Test'))
+    const meta = document.querySelector('meta[name="description"]')
+    expect(meta).toHaveAttribute('content', 'desc')
+  })
+})

--- a/tests/setup/integration-setup.ts
+++ b/tests/setup/integration-setup.ts
@@ -1,12 +1,19 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { toHaveNoViolations } from 'jest-axe'
-import { afterEach, expect } from 'vitest'
+import { afterEach, expect, vi } from 'vitest'
 
 expect.extend(toHaveNoViolations)
 
 afterEach(() => {
   cleanup()
+})
+
+// Mock canvas to prevent errors in tests
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  configurable: true,
+  writable: true,
+  value: vi.fn()
 })
 
 process.env.VITE_API_URL = 'http://localhost'

--- a/tests/utils/test-utils.tsx
+++ b/tests/utils/test-utils.tsx
@@ -9,6 +9,7 @@ import {
   waitFor
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HelmetProvider } from 'react-helmet-async'
 
 interface WrapperProps {
   initialEntries?: string[]
@@ -17,7 +18,11 @@ interface WrapperProps {
 const Providers: FC<PropsWithChildren<WrapperProps>> = ({
   children,
   initialEntries
-}) => <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+}) => (
+  <HelmetProvider context={{}}>
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  </HelmetProvider>
+)
 
 export const customRender = (
   ui: ReactElement,


### PR DESCRIPTION
## Summary
- install `react-helmet-async`
- wrap the app with `HelmetProvider`
- add `SEOHead` helper component
- update pages to include SEO metadata
- update testing utils for Helmet
- adjust integration setup for canvas mocking
- add component and page tests for SEOHead

## Testing
- `pnpm lint`
- `pnpm test` *(fails: App routing and Header tests)*

------
https://chatgpt.com/codex/tasks/task_e_68601a73e28c8322bb6881d56fbbd33a