### PR TITLE
Add skeleton loading component

### DIFF
--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Number of skeleton blocks to render */
+  count?: number
+}
+
+/**
+ * Generic loading skeleton.
+ * Renders animated placeholder blocks.
+ */
+const Skeleton: React.FC<SkeletonProps> = ({
+  count = 1,
+  className,
+  ...props
+}) => (
+  <div data-testid="skeleton-wrapper" {...props}>
+    {Array.from({ length: count }).map((_, i) => (
+      <div
+        key={i}
+        data-testid="skeleton-block"
+        className={cn(
+          'mb-2 h-4 w-full animate-pulse rounded-md bg-gray-200 last:mb-0 dark:bg-gray-700',
+          className
+        )}
+      />
+    ))}
+  </div>
+)
+
+Skeleton.displayName = 'Skeleton'
+
+export default Skeleton

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import Skeleton from '../Skeleton'
+
+describe('Skeleton component', () => {
+  it('renders default skeleton', () => {
+    render(<Skeleton />)
+    expect(screen.getAllByTestId('skeleton-block').length).toBe(1)
+  })
+
+  it('renders multiple skeleton blocks', () => {
+    render(<Skeleton count={3} />)
+    expect(screen.getAllByTestId('skeleton-block').length).toBe(3)
+  })
+
+  it('merges custom className', () => {
+    render(<Skeleton className="h-8" />)
+    const block = screen.getByTestId('skeleton-block')
+    expect(block).toHaveClass('h-8')
+  })
+})

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,3 +11,4 @@ export {
 } from './Card'
 export { Modal } from './Modal'
 export { ArticleCard } from './ArticleCard'
+export { default as Skeleton } from './Skeleton'

--- a/src/pages/Articles.tsx
+++ b/src/pages/Articles.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 
-import LoadingSpinner from '@/components/LoadingSpinner'
 import ArticleCard from '@/components/ui/ArticleCard'
+import Skeleton from '@/components/ui/Skeleton'
 
 import { useArticles } from '@/hooks/useArticles'
 
 const Articles: React.FC = () => {
   const { data, loading, error } = useArticles()
 
-  if (loading) return <LoadingSpinner />
+  if (loading) return <Skeleton count={6} className="h-48" />
 
   return (
     <main id="main-content" tabIndex={-1} className="p-4">


### PR DESCRIPTION
## Summary
- add Skeleton.tsx component with prop validation
- export Skeleton from ui index
- update Articles page to use Skeleton while loading
- test the new Skeleton component

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of undefined in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68602109ba508322987cfa27a9de4644