### PR TITLE
Add structured logger and tests

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 
 import { Button } from '@/components/ui/Button'
+import { logger } from '@/lib/logger'
 
 // NOTE: use this component via `@/components/ErrorBoundary`
 // Legacy path '@/components/layout/ErrorBoundary' has been removed.
@@ -33,9 +34,7 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ errorInfo })
-    console.error('ErrorBoundary caught', {
-      timestamp: new Date().toISOString(),
-      message: error.message,
+    logger.error('ErrorBoundary caught', error, {
       componentStack: errorInfo.componentStack
     })
     this.props.onError?.(error, errorInfo)

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { logger } from '../logger'
+
+describe('logger', () => {
+  it('logs info messages with timestamp', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logger.info('hello', { foo: 'bar' })
+    const [entry] = spy.mock.calls[0]
+    expect(entry).toEqual(
+      expect.objectContaining({
+        level: 'info',
+        timestamp: expect.any(String),
+        message: 'hello',
+        foo: 'bar'
+      })
+    )
+    spy.mockRestore()
+  })
+
+  it('logs error messages with stack', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const err = new Error('oops')
+    logger.error('failed', err, { id: 1 })
+    const [entry] = spy.mock.calls[0]
+    expect(entry).toEqual(
+      expect.objectContaining({
+        level: 'error',
+        timestamp: expect.any(String),
+        message: 'failed',
+        stack: err.stack,
+        id: 1
+      })
+    )
+    spy.mockRestore()
+  })
+})

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,28 @@
+export interface LogContext {
+  [key: string]: unknown
+}
+
+/**
+ * Basic structured logger used across client and server.
+ */
+export const logger = {
+  info(message: string, context: LogContext = {}): void {
+    const entry = {
+      level: 'info',
+      timestamp: new Date().toISOString(),
+      message,
+      ...context
+    }
+    console.log(entry)
+  },
+  error(message: string, error?: Error, context: LogContext = {}): void {
+    const entry = {
+      level: 'error',
+      timestamp: new Date().toISOString(),
+      message,
+      ...(error ? { stack: error.stack } : {}),
+      ...context
+    }
+    console.error(entry)
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,8 @@ import cors from 'cors'
 import express, { NextFunction, Request, Response } from 'express'
 import rateLimit from 'express-rate-limit'
 
+import { logger } from './lib/logger.js'
+
 import { securityMiddleware } from './server/security.js'
 
 class ConfigurationError extends Error {
@@ -97,7 +99,7 @@ export function createServer(distDir = path.join(__dirname, '..', 'dist')) {
 export function startServer(port = Number(process.env.PORT) || 3000) {
   const app = createServer()
   const server = app.listen(port, () => {
-    console.log(`Server running on port ${port}`)
+    logger.info(`Server running on port ${port}`)
   })
   return server
 }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3,9 +3,10 @@ import os from 'os'
 import path from 'path'
 
 import request from 'supertest'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createServer, startServer } from '../src/server'
+import { logger } from '../src/lib/logger'
 
 let tmpDir: string
 
@@ -50,6 +51,14 @@ describe('server nonce', () => {
     const server = startServer(0)
     expect(server).toBeTruthy()
     await new Promise((resolve) => server.close(resolve))
+  })
+
+  it('logs server start', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => {})
+    const server = startServer(0)
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Server running'))
+    server.close()
+    spy.mockRestore()
   })
 
   it('includes meta tags in served HTML', async () => {


### PR DESCRIPTION
## Summary
- implement simple structured `logger` utility
- use logger in `server.ts`
- use logger in `ErrorBoundary`
- test logger behavior and logging side effects

## Testing
- `npm run test` *(fails: Vitest reported failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68603d14f2208322aa45500e732cfe7e