### PR TITLE
Implement logger usage in ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 
 import { Button } from '@/components/ui/Button'
+
 import { logger } from '@/lib/logger'
 
 // NOTE: use this component via `@/components/ErrorBoundary`
@@ -35,7 +36,9 @@ export class ErrorBoundary extends Component<
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ errorInfo })
     logger.error('ErrorBoundary caught', error, {
-      componentStack: errorInfo.componentStack
+      componentStack: errorInfo.componentStack,
+      route: window.location.pathname,
+      hasFallback: Boolean(this.props.fallback)
     })
     this.props.onError?.(error, errorInfo)
   }

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import ErrorBoundary from '@/components/ErrorBoundary'
+
 import { logger } from '../src/lib/logger'
 
 const ProblemChild = () => {
@@ -70,7 +71,11 @@ describe('ErrorBoundary', () => {
     expect(errArg).toBeInstanceOf(Error)
     expect(errArg.message).toBe('boom')
     expect(context).toEqual(
-      expect.objectContaining({ componentStack: expect.any(String) })
+      expect.objectContaining({
+        componentStack: expect.any(String),
+        route: '/',
+        hasFallback: false
+      })
     )
 
     spy.mockRestore()


### PR DESCRIPTION
## Summary
- log errors from ErrorBoundary via logger module
- verify logger output in ErrorBoundary tests

## Testing
- `npx vitest run tests/ErrorBoundary.test.tsx`
- `npm run test` *(fails: TypeError Cannot read properties of undefined (reading 'add'))*

------
https://chatgpt.com/codex/tasks/task_e_68604188bdcc83229fd9f685a885fb32