### PR TITLE
Enhance dev server security headers

### DIFF
--- a/tests/viteHeaders.test.ts
+++ b/tests/viteHeaders.test.ts
@@ -1,0 +1,31 @@
+import config, { createDevHeaders, createDevNoncePlugin } from '../vite.config'
+import { describe, expect, it } from 'vitest'
+import type { UserConfig } from 'vite'
+
+describe('vite dev security config', () => {
+  it('adds security headers in development', () => {
+    const cfg = (config as (env: { mode: string; command: string }) => UserConfig)({ mode: 'development', command: 'serve' })
+    const headers = cfg.server.headers
+    expect(headers['X-Frame-Options']).toBe('DENY')
+    expect(headers['X-Content-Type-Options']).toBe('nosniff')
+    expect(headers['Strict-Transport-Security']).toContain('max-age')
+    expect(headers['Content-Security-Policy']).toContain('script-src')
+  })
+
+  it('does not add headers in production', () => {
+    const cfg = (config as (env: { mode: string; command: string }) => UserConfig)({ mode: 'production', command: 'build' })
+    expect(cfg.server.headers).toBeUndefined()
+  })
+
+  it('replaces nonce placeholder', () => {
+    const html = '<script nonce="__CSP_NONCE__"></script>'
+    const plugin = createDevNoncePlugin('abc')
+    const result = plugin.transformIndexHtml!(html)
+    expect(result).toContain('nonce="abc"')
+  })
+
+  it('creates headers with nonce', () => {
+    const h = createDevHeaders('xyz')
+    expect(h['Content-Security-Policy']).toContain('nonce-xyz')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,9 @@ import path from 'path'
 
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import { imagetools } from 'vite-imagetools'
+import { randomBytes } from 'crypto'
 const require = createRequire(import.meta.url)
 let compressPlugin: (() => unknown) | null = null
 if (process.env.USE_COMPRESS_PLUGIN === 'true') {
@@ -18,11 +19,44 @@ if (process.env.USE_COMPRESS_PLUGIN === 'true') {
 const manualChunks = (id: string) =>
   id.includes('node_modules') ? 'vendor' : undefined
 
+export function createDevHeaders(nonce: string) {
+  return {
+    'Content-Security-Policy': [
+      "default-src 'self'",
+      `script-src 'self' https://cdn.jsdelivr.net 'nonce-${nonce}'`,
+      `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`,
+      "font-src 'self' https://fonts.gstatic.com",
+      "img-src 'self' data: https:",
+      "connect-src 'self' https://api.artofficial-intelligence.com ws:"
+    ].join('; '),
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Strict-Transport-Security': 'max-age=31536000'
+  } as const
+}
+
+export function createDevNoncePlugin(nonce: string): Plugin {
+  return {
+    name: 'dev-html-nonce',
+    apply: 'serve',
+    transformIndexHtml(html) {
+      return html.replace(/__CSP_NONCE__/g, nonce)
+    }
+  }
+}
+
 export default defineConfig(({ mode }) => {
   const plugins = [react(), imagetools()]
   if (compressPlugin) plugins.push(compressPlugin())
   if (mode === 'analyze')
     plugins.push(visualizer({ open: true, gzipSize: true, brotliSize: true }))
+
+  let headers: Record<string, string> | undefined
+  if (mode === 'development') {
+    const nonce = randomBytes(16).toString('base64')
+    headers = createDevHeaders(nonce)
+    plugins.push(createDevNoncePlugin(nonce))
+  }
 
   return {
     plugins,
@@ -41,7 +75,8 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: 3000,
-      open: true
+      open: true,
+      ...(headers ? { headers } : {})
     }
   }
 })


### PR DESCRIPTION
## Summary
- add development security headers with CSP and other hardening
- inject nonce into dev HTML
- test configuration for dev security

## Testing
- `npm run type-check` *(fails: Missing script)*
- `npm run test:coverage` *(fails: jsdom TextEncoder issue)*
- `npm run security:audit` *(fails: Missing script)*
- `npm run performance` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68605f54789c8322b800847fcf9d750d