### PR TITLE
Add CSP security utilities and test helper

### DIFF
--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCspDirectives, generateNonce } from '../security'
+
+describe('security utilities', () => {
+  it('generates a base64 nonce', () => {
+    const nonce = generateNonce()
+    expect(nonce).toMatch(/^[a-zA-Z0-9+/]+={0,2}$/)
+    expect(nonce.length).toBeGreaterThan(0)
+  })
+
+  it('creates CSP directives with provided nonce', () => {
+    const directives = createCspDirectives('abc')
+    expect(directives.scriptSrc).toContain("'nonce-abc'")
+  })
+})

--- a/src/lib/security/index.ts
+++ b/src/lib/security/index.ts
@@ -1,0 +1,38 @@
+import { webcrypto } from 'crypto'
+
+export interface CspDirectives {
+  defaultSrc: string[]
+  scriptSrc: string[]
+  styleSrc: string[]
+  fontSrc: string[]
+  imgSrc: string[]
+  connectSrc: string[]
+}
+
+export function generateNonce(): string {
+  const arr = new Uint8Array(16)
+  webcrypto.getRandomValues(arr)
+  return Buffer.from(arr).toString('base64')
+}
+
+export function createCspDirectives(nonce: string): CspDirectives {
+  return {
+    defaultSrc: ["'self'"],
+    scriptSrc: ["'self'", 'https://cdn.jsdelivr.net', `'nonce-${nonce}'`],
+    styleSrc: ["'self'", `'nonce-${nonce}'`, 'https://fonts.googleapis.com'],
+    fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+    imgSrc: ["'self'", 'data:', 'https:'],
+    connectSrc: ["'self'", 'https://api.artofficial-intelligence.com', 'ws:']
+  } as const
+}
+
+export interface SecurityHeaders {
+  'Content-Security-Policy': string
+  'X-Frame-Options': string
+  'X-Content-Type-Options': string
+  'Strict-Transport-Security': string
+  'Referrer-Policy'?: string
+  'X-Permitted-Cross-Domain-Policies'?: string
+  'Cross-Origin-Opener-Policy'?: string
+  'Permissions-Policy'?: string
+}

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -1,33 +1,8 @@
-import { webcrypto } from 'crypto'
-
 import helmet from 'helmet'
 
+import { createCspDirectives, generateNonce } from '@/lib/security'
+
 import type { NextFunction, Request, Response } from 'express'
-
-export function generateNonce() {
-  const arr = new Uint8Array(16)
-  webcrypto.getRandomValues(arr)
-  return Buffer.from(arr).toString('base64')
-}
-
-function createDirectives(res: Response) {
-  return {
-    defaultSrc: ["'self'"],
-    scriptSrc: [
-      "'self'",
-      'https://cdn.jsdelivr.net',
-      `'nonce-${res.locals.nonce as string}'`
-    ],
-    styleSrc: [
-      "'self'",
-      `'nonce-${res.locals.nonce as string}'`,
-      'https://fonts.googleapis.com'
-    ],
-    fontSrc: ["'self'", 'https://fonts.gstatic.com'],
-    imgSrc: ["'self'", 'data:', 'https:'],
-    connectSrc: ["'self'", 'https://api.artofficial-intelligence.com', 'ws:']
-  } as const
-}
 
 export function securityMiddleware() {
   return [
@@ -38,7 +13,7 @@ export function securityMiddleware() {
     (req: Request, res: Response, next: NextFunction) =>
       helmet.contentSecurityPolicy({
         useDefaults: false,
-        directives: createDirectives(res)
+        directives: createCspDirectives(res.locals.nonce as string)
       })(req, res, next),
     helmet.referrerPolicy({ policy: 'no-referrer' }),
     helmet.permittedCrossDomainPolicies(),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { logger } from '../src/lib/logger'
 import { createServer, startServer } from '../src/server'
+import { validateSecurityHeaders } from './utils/security-headers'
 
 let tmpDir: string
 
@@ -113,14 +114,7 @@ describe('server nonce', () => {
     await fs.writeFile(path.join(tmpDir, 'index.html'), '<!doctype html>')
     const app = createServer(tmpDir)
     const res = await request(app).get('/')
-    expect(res.headers['x-frame-options']).toBe('DENY')
-    expect(res.headers['x-content-type-options']).toBe('nosniff')
-    expect(res.headers['referrer-policy']).toBe('no-referrer')
-    expect(res.headers['x-permitted-cross-domain-policies']).toBe('none')
-    expect(res.headers['cross-origin-opener-policy']).toBe('same-origin')
-    expect(res.headers['permissions-policy']).toBe(
-      'geolocation=(), microphone=()'
-    )
+    validateSecurityHeaders(res.headers as Record<string, string>)
   })
 
   it('throws if CORS_ORIGIN is missing', () => {

--- a/tests/utils/security-headers.test.ts
+++ b/tests/utils/security-headers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateSecurityHeaders } from './security-headers'
+
+describe('validateSecurityHeaders', () => {
+  it('passes when headers match', () => {
+    const headers = {
+      'x-frame-options': 'DENY',
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'no-referrer',
+      'x-permitted-cross-domain-policies': 'none',
+      'cross-origin-opener-policy': 'same-origin',
+      'permissions-policy': 'geolocation=(), microphone=()'
+    }
+    expect(() => validateSecurityHeaders(headers)).not.toThrow()
+  })
+})

--- a/tests/utils/security-headers.ts
+++ b/tests/utils/security-headers.ts
@@ -1,0 +1,10 @@
+import { expect } from 'vitest'
+
+export function validateSecurityHeaders(headers: Record<string, string>): void {
+  expect(headers['x-frame-options']).toBe('DENY')
+  expect(headers['x-content-type-options']).toBe('nosniff')
+  expect(headers['referrer-policy']).toBe('no-referrer')
+  expect(headers['x-permitted-cross-domain-policies']).toBe('none')
+  expect(headers['cross-origin-opener-policy']).toBe('same-origin')
+  expect(headers['permissions-policy']).toBe('geolocation=(), microphone=()')
+}


### PR DESCRIPTION
## Summary
- share CSP utilities in src/lib/security
- update server security middleware to use shared utilities
- add helper for validating security headers
- test new security utilities and helper

## Testing
- `npm run lint`
- `npm run test` *(fails: Invariant violation new TextEncoder, esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_686077f3163c83229ae59b699f97b96a