### PR TITLE
Standardize Express error handling

### DIFF
--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,0 +1,71 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { logger } from '@/lib/logger'
+
+import type { NextFunction, Request, Response } from 'express'
+
+export interface ErrorDetails {
+  message: string
+  code?: string
+  field?: string
+}
+
+export interface ErrorMeta {
+  timestamp: string
+  correlationId: string
+}
+
+export interface ErrorResponse {
+  success: false
+  error: ErrorDetails
+  meta: ErrorMeta
+}
+
+export class HttpError extends Error {
+  status: number
+  code?: string
+
+  constructor(message: string, status = 500, code?: string) {
+    super(message)
+    this.name = 'HttpError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export function createErrorResponse(
+  err: HttpError | Error,
+  correlationId: string
+): ErrorResponse {
+  const status = err instanceof HttpError ? err.status : 500
+  const message = status >= 500 ? 'Internal server error' : err.message
+  return {
+    success: false,
+    error: {
+      message,
+      ...(err instanceof HttpError && err.code ? { code: err.code } : {})
+    },
+    meta: { timestamp: new Date().toISOString(), correlationId }
+  }
+}
+
+export function requestIdMiddleware() {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const id = uuidv4()
+    res.locals.correlationId = id
+    res.setHeader('X-Correlation-Id', id)
+    next()
+  }
+}
+
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response
+): void {
+  const id = (res.locals.correlationId as string) || uuidv4()
+  const httpErr = err instanceof HttpError ? err : new HttpError(err.message)
+  logger.error(httpErr.message, httpErr, { correlationId: id })
+  const body = createErrorResponse(httpErr, id)
+  res.status(httpErr.status).json(body)
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -29,6 +29,7 @@ describe('server nonce', () => {
     const app = createServer(tmpDir)
     const res = await request(app).get('/')
     expect(res.status).toBe(200)
+    expect(res.headers['x-correlation-id']).toBeTruthy()
     const csp = res.headers['content-security-policy'] as string
     const nonceMatch = csp.match(/nonce-([^';]+)/)
     expect(nonceMatch).toBeTruthy()
@@ -47,6 +48,8 @@ describe('server nonce', () => {
     const app = createServer(tmpDir)
     const res = await request(app).get('/')
     expect(res.status).toBe(500)
+    expect(res.body.success).toBe(false)
+    expect(res.body.meta.correlationId).toBeTruthy()
   })
 
   it('startServer returns http.Server', async () => {
@@ -131,7 +134,8 @@ describe('server nonce', () => {
     await fs.writeFile(path.join(tmpDir, 'index.html'), '<!doctype html>')
     const app = createServer(tmpDir)
     const res = await request(app).get('/').set('Origin', 'http://bad.com')
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('INVALID_ORIGIN')
   })
 })
 


### PR DESCRIPTION
## Summary
- add `HttpError` class and helpers
- implement centralized error middleware with correlation IDs
- update server to use middleware and new error responses
- adjust tests for new error format

## Testing
- `npm run lint`
- `npm test` *(fails: 11 failed, 100 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686148bd61188322a535db4e0af218b1