### PR TITLE
[tests] add service worker mocks

### DIFF
--- a/src/components/ServiceWorkerProvider.tsx
+++ b/src/components/ServiceWorkerProvider.tsx
@@ -41,7 +41,7 @@ export const ServiceWorkerProvider: React.FC<Props> = ({ children }) => {
     })
     return () => {
       if (reg && typeof reg.unregister === 'function') {
-        reg.unregister().catch(() => {})
+        void Promise.resolve(reg.unregister()).catch(() => {})
       }
     }
   }, [])

--- a/tests/setup/service-worker-mock.ts
+++ b/tests/setup/service-worker-mock.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest'
+
+Object.assign(globalThis, {
+  self: {
+    skipWaiting: vi.fn(),
+    clientsClaim: vi.fn(),
+    addEventListener: vi.fn(),
+    __WB_MANIFEST: []
+  }
+})
+
+vi.mock(
+  'workbox-recipes/warmStrategyCache',
+  () => ({ warmStrategyCache: vi.fn() }),
+  { virtual: true }
+)
+vi.mock(
+  'workbox-recipes/warmStrategyCache.js',
+  () => ({ warmStrategyCache: vi.fn() }),
+  { virtual: true }
+)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
   test: {
     environment: 'jsdom',
-    setupFiles: ['./tests/setup/integration-setup.ts'],
+    setupFiles: [
+      './tests/setup/integration-setup.ts',
+      './tests/setup/service-worker-mock.ts'
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
- mock service worker functions in test setup
- include new service worker mock setup in Vitest config
- guard unregister cleanup in ServiceWorkerProvider

## Testing
- `pnpm test -- -t "service worker"` *(fails: Cannot read properties of undefined (reading 'add'))*

------
https://chatgpt.com/codex/tasks/task_e_68618ff5e3b8832284cdd7c94ed22dde