### PR TITLE
[tests] use helper render in App test

### DIFF
--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,42 +1,30 @@
 import '@testing-library/jest-dom/vitest'
-import { MemoryRouter } from 'react-router-dom'
-
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import App from '@/App'
+
+import { render, screen } from './utils/test-utils'
 
 afterEach(cleanup)
 
 describe('App routing', () => {
   it('renders home page', async () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <App />
-      </MemoryRouter>
-    )
+    render(<App />, { initialEntries: ['/'] })
     expect(
       await screen.findByRole('heading', { name: /artofficial intelligence/i })
     ).toBeInTheDocument()
   })
 
   it('navigates to articles page', async () => {
-    render(
-      <MemoryRouter initialEntries={['/articles']}>
-        <App />
-      </MemoryRouter>
-    )
+    render(<App />, { initialEntries: ['/articles'] })
     expect(
       await screen.findByRole('heading', { name: /articles/i })
     ).toBeInTheDocument()
   })
 
   it('shows not found page for unknown route', async () => {
-    render(
-      <MemoryRouter initialEntries={['/missing']}>
-        <App />
-      </MemoryRouter>
-    )
+    render(<App />, { initialEntries: ['/missing'] })
     expect(await screen.findByText(/Page Not Found/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- update App test to leverage custom test-utils

## Testing
- `pnpm test` *(fails: Cannot find module 'workbox-recipes/warmStrategyCache')*

------
https://chatgpt.com/codex/tasks/task_e_686194c4c710832286992510488b97b3