### PR TITLE
[tests] add TextEncoder polyfill to integration setup

### DIFF
--- a/tests/setup/integration-setup.ts
+++ b/tests/setup/integration-setup.ts
@@ -2,6 +2,11 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { toHaveNoViolations } from 'jest-axe'
 import { afterEach, expect, vi } from 'vitest'
+import { TextEncoder } from 'util'
+
+if (!global.TextEncoder) {
+  global.TextEncoder = TextEncoder
+}
 
 expect.extend(toHaveNoViolations)
 


### PR DESCRIPTION
## Summary
- ensure TextEncoder is globally defined during integration tests

## Testing
- `pnpm test tests/viteHeaders.test.ts --run` *(fails: Invariant violation)*

------
https://chatgpt.com/codex/tasks/task_e_686199b1fe4c8322ae383d7b35a46c7e