### PR TITLE
[security] enforce strict CSP with nonce middleware

### DIFF
--- a/src/components/CspNonceProvider.tsx
+++ b/src/components/CspNonceProvider.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext } from 'react'
+
+interface Props {
+  nonce: string
+  children: React.ReactNode
+}
+
+class CspNonceError extends Error {
+  constructor() {
+    super('CSP nonce not available')
+    this.name = 'CspNonceError'
+  }
+}
+
+const CspNonceContext = createContext<string | undefined>(undefined)
+
+export const useCspNonce = (): string => {
+  const nonce = useContext(CspNonceContext)
+  if (!nonce) throw new CspNonceError()
+  return nonce
+}
+
+export const CspNonceProvider: React.FC<Props> = ({ nonce, children }) => (
+  <CspNonceContext.Provider value={nonce}>{children}</CspNonceContext.Provider>
+)
+
+export default CspNonceProvider

--- a/src/components/__tests__/CspNonceProvider.test.tsx
+++ b/src/components/__tests__/CspNonceProvider.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import CspNonceProvider, { useCspNonce } from '../CspNonceProvider'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CspNonceProvider nonce="test-nonce">{children}</CspNonceProvider>
+)
+
+describe('CspNonceProvider', () => {
+  it('provides nonce via context', () => {
+    const { result } = renderHook(() => useCspNonce(), { wrapper })
+    expect(result.current).toBe('test-nonce')
+  })
+
+  it('throws when nonce missing', () => {
+    const { result } = renderHook(() => {
+      try {
+        return useCspNonce()
+      } catch (e) {
+        return e
+      }
+    })
+    expect(result.current).toBeInstanceOf(Error)
+  })
+})

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -21,7 +21,8 @@ const baseSchema = z.object({
   PORT: z.coerce.number().int().min(1).max(65535).default(3000),
   REDIS_URL: redisUrlSchema,
   CORS_ORIGIN: corsOriginSchema,
-  JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters')
+  JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters'),
+  CSP_REPORT_URI: z.string().url().optional()
 })
 
 export type Env = z.infer<typeof baseSchema>

--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -3,14 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { createCspDirectives, generateNonce } from '../security'
 
 describe('security utilities', () => {
-  it('generates a base64 nonce', () => {
-    const nonce = generateNonce()
-    expect(nonce).toMatch(/^[a-zA-Z0-9+/]+={0,2}$/)
-    expect(nonce.length).toBeGreaterThan(0)
+  it('generates a unique base64 nonce', () => {
+    const a = generateNonce()
+    const b = generateNonce()
+    expect(a).toMatch(/^[a-zA-Z0-9+/]+={0,2}$/)
+    expect(a).not.toBe(b)
   })
 
-  it('creates CSP directives with provided nonce', () => {
-    const directives = createCspDirectives('abc')
+  it('creates CSP directives with provided options', () => {
+    const directives = createCspDirectives('abc', {
+      env: 'development',
+      reportUri: 'https://csp.example.com'
+    })
     expect(directives.scriptSrc).toContain("'nonce-abc'")
+    expect(directives.connectSrc).toContain('ws:')
+    expect(directives.reportUri).toEqual(['https://csp.example.com'])
   })
 })

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,14 +73,17 @@ export async function createServer(distDir = path.join(__dirname, '..', 'dist'))
     }
   )
 
-  app.post(
-    '/csp-report',
-    express.json({ type: ['json', 'application/csp-report'] }),
-    (_req, res) => {
-      console.warn('CSP Violation', _req.body)
-      res.status(204).end()
-    }
-  )
+  const reportEndpoint = env.CSP_REPORT_URI || '/csp-report'
+  if (reportEndpoint.startsWith('/')) {
+    app.post(
+      reportEndpoint,
+      express.json({ type: ['json', 'application/csp-report'] }),
+      (_req, res) => {
+        console.warn('CSP Violation', _req.body)
+        res.status(204).end()
+      }
+    )
+  }
 
   app.use(express.static(distDir))
 

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -1,5 +1,6 @@
 import helmet from 'helmet'
 
+import { env } from '@/config/environment'
 import { createCspDirectives, generateNonce } from '@/lib/security'
 
 import type { NextFunction, Request, Response } from 'express'
@@ -13,7 +14,10 @@ export function securityMiddleware() {
     (req: Request, res: Response, next: NextFunction) =>
       helmet.contentSecurityPolicy({
         useDefaults: false,
-        directives: createCspDirectives(res.locals.nonce as string) as unknown as Record<string, string[]>
+        directives: createCspDirectives(res.locals.nonce as string, {
+          env: env.NODE_ENV,
+          reportUri: env.CSP_REPORT_URI || '/csp-report'
+        }) as unknown as Record<string, string[]>
       })(req, res, next),
     helmet.referrerPolicy({ policy: 'no-referrer' }),
     helmet.permittedCrossDomainPolicies(),

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -12,7 +12,8 @@ describe('environment validation', () => {
     PORT: '3000',
     CORS_ORIGIN: 'http://localhost:3000',
     REDIS_URL: 'redis://localhost:6379',
-    JWT_SECRET: 'a'.repeat(32)
+    JWT_SECRET: 'a'.repeat(32),
+    CSP_REPORT_URI: 'https://csp.example.com/report'
   }
 
   it('throws when required variable missing', () => {
@@ -39,5 +40,6 @@ describe('environment validation', () => {
     const env = validateEnv()
     expect(env.PORT).toBe(3000)
     expect(env.CORS_ORIGIN).toEqual(['http://localhost:3000'])
+    expect(env.CSP_REPORT_URI).toBe('https://csp.example.com/report')
   })
 })


### PR DESCRIPTION
## Summary
- generate cryptographically secure nonce using `crypto.randomBytes`
- enhance CSP directives with strict defaults and optional reporting
- expose environment variable `CSP_REPORT_URI`
- provide CSP nonce React context provider
- adjust server middleware to use new directives
- update tests for environment and CSP changes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Invalid environment variables / esbuild issues)*
- `pnpm build`
- `pnpm analyze`


------
https://chatgpt.com/codex/tasks/task_e_6861cb448a308322b1660750d5b3bd49